### PR TITLE
fix(client): include inflow fees in instant-loan deposits

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,13 @@ const loan = await client.instantLoans.create({
 });
 
 console.log("Save this loan reference:", loan.ref);
+console.log("Send initial deposit amount:", loan.initialDeposit.amount.toString());
 console.log("Send collateral to:", formatSupplyTarget(loan.depositTarget));
 
 const restoredLoan = await client.instantLoans.get({ ref: loan.ref });
 
 console.log("Loan status:", restoredLoan.status);
+console.log("Restored initial deposit amount:", restoredLoan.initialDeposit.amount.toString());
 console.log("Repay amount:", restoredLoan.repayment.amount.toString());
 console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
 
@@ -147,11 +149,11 @@ Instant-loan integrations use this sequence:
 | --- | --- | --- |
 | Load market data | `client.market.listPools()` and `client.market.getAssetPrices()` | Show supported collateral and borrow assets |
 | Validate amounts | `client.quote.calculateLtv(...)` | Block invalid LTV or frozen-pool input before creating a loan |
-| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.depositTarget` |
-| Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state and monitor deposit, borrow, and repayment activity |
+| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.depositTarget` |
+| Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state, initial deposit quote, and repayment activity |
 | Repay loan | Read `loan.repayment` | Ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
 
-`client.instantLoans.create(...)` returns the generated Liquidium profile, transfer targets, current position state, and repayment quote. Users do not manage the generated profile.
+`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, transfer targets, current position state, an initial deposit quote, and a repayment quote. Users do not manage the generated profile.
 
 ## Core API
 
@@ -165,7 +167,7 @@ Creates an accountless instant loan and returns generated transfer targets.
 | `borrowPoolId` | Pool the loan borrows from |
 | `collateralAsset` | Collateral asset symbol, for example `"BTC"` |
 | `borrowAsset` | Borrow asset symbol, for example `"USDC"` |
-| `collateralAmount` | Collateral amount in base units |
+| `collateralAmount` | Intended credited collateral amount in base units, before deposit/inflow fees |
 | `borrowAmount` | Borrow amount in base units |
 | `ltvMaxBps` | Maximum LTV in basis points, where `6_000n` is 60% |
 | `depositWindowSeconds` | How long the user has to send collateral |
@@ -178,7 +180,7 @@ Creates an accountless instant loan and returns generated transfer targets.
 
 Loads loan state from a saved user-facing reference.
 
-Use this for status pages, refreshes, and support links.
+Use this for status pages, refreshes, and support links. The SDK combines canister state with the Liquidium SDK API lookup so the restored loan includes the original collateral deposit hint.
 
 ### `client.instantLoans.get({ loanId })`
 
@@ -206,6 +208,8 @@ Most instant-loan UIs show or store these fields:
 | --- | --- |
 | `loan.ref` | Save and show this reference so the loan can be restored later |
 | `loan.status` | Show the lifecycle: `awaiting_deposit`, `deposit_detected`, `active`, `settling`, or `closed` |
+| `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
+| `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.depositTarget` | Address or ICRC account where the user sends collateral |
 | `loan.repayment.amount` | Full amount to repay, including fee and interest buffer |
 | `loan.repayment.target` | Address or ICRC account where the user sends repayment |

--- a/README.md
+++ b/README.md
@@ -105,14 +105,18 @@ const loan = await client.instantLoans.create({
 
 console.log("Save this loan reference:", loan.ref);
 console.log("Send initial deposit amount:", loan.initialDeposit.amount.toString());
-console.log("Send collateral to:", formatSupplyTarget(loan.depositTarget));
+console.log("Send collateral to:", formatSupplyTarget(loan.initialDeposit.target));
 
 const restoredLoan = await client.instantLoans.get({ ref: loan.ref });
 
 console.log("Loan status:", restoredLoan.status);
 console.log("Restored initial deposit amount:", restoredLoan.initialDeposit.amount.toString());
-console.log("Repay amount:", restoredLoan.repayment.amount.toString());
-console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
+if (restoredLoan.repayment) {
+  console.log("Repay amount:", restoredLoan.repayment.amount.toString());
+  console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
+} else {
+  console.log("No repayment due yet.");
+}
 
 const activities = await client.activities.list({ shortRef: loan.ref });
 
@@ -149,11 +153,11 @@ Instant-loan integrations use this sequence:
 | --- | --- | --- |
 | Load market data | `client.market.listPools()` and `client.market.getAssetPrices()` | Show supported collateral and borrow assets |
 | Validate amounts | `client.quote.calculateLtv(...)` | Block invalid LTV or frozen-pool input before creating a loan |
-| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.depositTarget` |
+| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.initialDeposit.target` |
 | Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state, initial deposit quote, and repayment activity |
-| Repay loan | Read `loan.repayment` | Ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
+| Repay loan | Read `loan.repayment` | If non-null, ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
 
-`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, transfer targets, current position state, an initial deposit quote, and a repayment quote. Users do not manage the generated profile.
+`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, current position state, an initial deposit quote with its transfer target, and a nullable repayment quote with its transfer target. Users do not manage the generated profile.
 
 ## Core API
 
@@ -207,12 +211,12 @@ Most instant-loan UIs show or store these fields:
 | Field | Use |
 | --- | --- |
 | `loan.ref` | Save and show this reference so the loan can be restored later |
-| `loan.status` | Show the lifecycle: `awaiting_deposit`, `deposit_detected`, `active`, `settling`, or `closed` |
+| `loan.status` | Show the lifecycle: `awaiting_deposit`, `deposit_detected`, `active`, `settling`, `closed`, or `expired` |
 | `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
-| `loan.depositTarget` | Address or ICRC account where the user sends collateral |
-| `loan.repayment.amount` | Full amount to repay, including fee and interest buffer |
-| `loan.repayment.target` | Address or ICRC account where the user sends repayment |
+| `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
+| `loan.repayment?.amount` | Full amount to repay, including fee and interest buffer, when debt exists |
+| `loan.repayment?.target` | Address or ICRC account where the user sends repayment, when debt exists |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |
 
 ## Amounts
@@ -224,7 +228,7 @@ The SDK returns amount fields as `bigint` values in the asset's smallest unit.
 | BTC | Satoshis |
 | USDC / USDT | Token base units using the pool decimals |
 
-Use `Pool.decimals` from `client.market.listPools()` when converting user-entered decimals to base units.
+Use `Pool.decimals` from `client.market.listPools()` when converting user-entered decimals to base units. Hydrated instant loans also include `loan.collateral.decimals`, `loan.borrow.decimals`, and `loan.initialDeposit.decimals` for display.
 
 ## Status And Activity Tracking
 

--- a/examples/instant-loans-flow/src/App.tsx
+++ b/examples/instant-loans-flow/src/App.tsx
@@ -149,15 +149,15 @@ export function App() {
         "",
         `Amount to send: ${formatAmount(
           loan.initialDeposit.amount,
-          collateralPool.decimals
+          loan.initialDeposit.decimals
         )} ${collateralPool.asset}`,
         `Credited collateral: ${formatAmount(
           loan.initialDeposit.collateralAmount,
-          collateralPool.decimals
+          loan.initialDeposit.decimals
         )} ${collateralPool.asset}`,
         `Estimated inflow fee: ${formatAmount(
           loan.initialDeposit.inflowFeeAmount,
-          collateralPool.decimals
+          loan.initialDeposit.decimals
         )} ${collateralPool.asset}`,
         `Borrow amount: ${formatAmount(
           parsedBorrowAmount,

--- a/examples/instant-loans-flow/src/App.tsx
+++ b/examples/instant-loans-flow/src/App.tsx
@@ -145,13 +145,27 @@ export function App() {
     setRecentLoanRefs(getRecentLoanRefs());
     setLoanResult(
       [
-        "Loan created. Save the reference and send collateral to the deposit target.",
+        "Loan created. Save the reference and send the initial deposit amount to the deposit target.",
         "",
-        `Collateral amount: ${formatAmount(parsedCollateralAmount, collateralPool.decimals)} ${collateralPool.asset}`,
-        `Borrow amount: ${formatAmount(parsedBorrowAmount, borrowPool.decimals)} ${borrowPool.asset}`,
+        `Amount to send: ${formatAmount(
+          loan.initialDeposit.amount,
+          collateralPool.decimals
+        )} ${collateralPool.asset}`,
+        `Credited collateral: ${formatAmount(
+          loan.initialDeposit.collateralAmount,
+          collateralPool.decimals
+        )} ${collateralPool.asset}`,
+        `Estimated inflow fee: ${formatAmount(
+          loan.initialDeposit.inflowFeeAmount,
+          collateralPool.decimals
+        )} ${collateralPool.asset}`,
+        `Borrow amount: ${formatAmount(
+          parsedBorrowAmount,
+          borrowPool.decimals
+        )} ${borrowPool.asset}`,
         `Max LTV: ${formatPercentFromBps(ltvMaxBps)}`,
         "",
-        formatInstantLoan(loan),
+        formatInstantLoan(loan, { pools }),
       ].join("\n")
     );
     setStatus(`Created instant loan ${loan.ref}.`);
@@ -316,8 +330,12 @@ export function App() {
 
       return [
         "Prices used for LTV:",
-        `Collateral ${collateralPool.asset}: ${formatUsdPrice(assetPrices[collateralPool.asset])}`,
-        `Borrow ${borrowPool.asset}: ${formatUsdPrice(assetPrices[borrowPool.asset])}`,
+        `Collateral ${collateralPool.asset}: ${formatUsdPrice(
+          assetPrices[collateralPool.asset]
+        )}`,
+        `Borrow ${borrowPool.asset}: ${formatUsdPrice(
+          assetPrices[borrowPool.asset]
+        )}`,
         "Source: Liquidium market data.",
       ].join("\n");
     } catch {
@@ -358,7 +376,9 @@ export function App() {
       return [
         `Implied current LTV: ${formatPercentFromBps(ltvCalculation.ltvBps)}`,
         `User max LTV: ${formatPercentFromBps(ltvMaxBps)}`,
-        `SDK max allowed LTV: ${formatPercentFromBps(ltvCalculation.maxAllowedLtvBps)}`,
+        `SDK max allowed LTV: ${formatPercentFromBps(
+          ltvCalculation.maxAllowedLtvBps
+        )}`,
         ltvMaxBps > ltvCalculation.maxAllowedLtvBps
           ? "Warning: user max LTV is above the SDK max allowed LTV."
           : "User max LTV is within the SDK max allowed LTV.",

--- a/examples/instant-loans-flow/src/format.ts
+++ b/examples/instant-loans-flow/src/format.ts
@@ -14,6 +14,10 @@ const RECENT_LOANS_STORAGE_KEY = "liquidium-instant-loans.recentRefs";
 const MAX_RECENT_LOANS = 10;
 const ERROR_FIELD_EXCLUDE_LIST = new Set(["name", "message", "stack", "cause"]);
 
+type InstantLoanFormatOptions = {
+  pools?: Pool[];
+};
+
 export function getElement<T extends HTMLElement>(id: string): T {
   const element = document.getElementById(id);
 
@@ -116,7 +120,9 @@ export function formatPool(pool: Pool): string {
   return [
     `${pool.asset} on ${pool.chain}`,
     `Pool: ${pool.id}`,
-    `Available: ${formatAmount(pool.availableLiquidity, pool.decimals)} ${pool.asset}`,
+    `Available: ${formatAmount(pool.availableLiquidity, pool.decimals)} ${
+      pool.asset
+    }`,
     `Max LTV: ${formatPercentFromBps(pool.maxLtv)}`,
     `Frozen: ${pool.frozen ? "yes" : "no"}`,
   ].join("\n");
@@ -139,7 +145,21 @@ export function formatSupplyTarget(target: SupplyTarget): string {
   ].join("\n");
 }
 
-export function formatInstantLoan(loan: InstantLoan): string {
+export function formatInstantLoan(
+  loan: InstantLoan,
+  options: InstantLoanFormatOptions = {}
+): string {
+  const collateralDecimals = getInstantLoanPoolDecimals(
+    options.pools,
+    loan.collateral.poolId,
+    loan.position.collateralDecimals
+  );
+  const borrowDecimals = getInstantLoanPoolDecimals(
+    options.pools,
+    loan.borrow.poolId,
+    loan.repayment.decimals
+  );
+
   return [
     `Reference: ${loan.ref}`,
     `Loan id: ${loan.loanId.toString()}`,
@@ -149,11 +169,15 @@ export function formatInstantLoan(loan: InstantLoan): string {
     `Deposit window seconds: ${loan.depositWindowSeconds.toString()}`,
     "",
     "Collateral:",
-    `${loan.collateral.amount.toString()} base units of ${loan.collateral.asset} on ${loan.collateral.chain}`,
+    `${formatAmount(loan.collateral.amount, collateralDecimals)} ${
+      loan.collateral.asset
+    } on ${loan.collateral.chain}`,
     `Pool: ${loan.collateral.poolId}`,
     "",
     "Borrow:",
-    `Amount: ${loan.borrow.amount.toString()} base units of ${loan.borrow.asset} on ${loan.borrow.chain}`,
+    `Amount: ${formatAmount(loan.borrow.amount, borrowDecimals)} ${
+      loan.borrow.asset
+    } on ${loan.borrow.chain}`,
     `Destination: ${formatInstantLoanAccount(loan.borrow.destination)}`,
     `Pool: ${loan.borrow.poolId}`,
     "",
@@ -162,50 +186,73 @@ export function formatInstantLoan(loan: InstantLoan): string {
     "Deposit target:",
     formatSupplyTarget(loan.depositTarget),
     "",
+    "Initial deposit quote:",
+    `Amount to send: ${formatAmount(
+      loan.initialDeposit.amount,
+      collateralDecimals
+    )} ${loan.initialDeposit.asset} on ${loan.initialDeposit.chain}`,
+    `Credited collateral: ${formatAmount(
+      loan.initialDeposit.collateralAmount,
+      collateralDecimals
+    )} ${loan.initialDeposit.asset}`,
+    `Estimated inflow fee: ${formatAmount(
+      loan.initialDeposit.inflowFeeAmount,
+      collateralDecimals
+    )} ${loan.initialDeposit.asset}`,
+    "",
     "Current position:",
-    `Collateral: ${formatAmountWithBaseUnits(
+    `Collateral: ${formatAmount(
       loan.position.collateralAmount,
-      loan.position.collateralDecimals
+      collateralDecimals
     )} ${loan.collateral.asset}`,
-    `Collateral interest: ${formatAmountWithBaseUnits(
+    `Collateral interest: ${formatAmount(
       loan.position.collateralInterestAmount,
-      loan.position.collateralDecimals
+      collateralDecimals
     )} ${loan.collateral.asset}`,
-    `Borrowed: ${formatAmountWithBaseUnits(
-      loan.position.borrowedAmount,
-      loan.position.borrowedDecimals
-    )} ${loan.borrow.asset}`,
-    `Debt interest: ${formatAmountWithBaseUnits(
+    `Borrowed: ${formatAmount(loan.position.borrowedAmount, borrowDecimals)} ${
+      loan.borrow.asset
+    }`,
+    `Debt interest: ${formatAmount(
       loan.position.debtInterestAmount,
-      loan.position.borrowedDecimals
+      borrowDecimals
     )} ${loan.borrow.asset}`,
-    `Total debt: ${formatAmountWithBaseUnits(
+    `Total debt: ${formatAmount(
       loan.position.totalDebtAmount,
-      loan.position.borrowedDecimals
+      borrowDecimals
     )} ${loan.borrow.asset}`,
     "",
     "Repayment quote:",
-    `Amount to repay: ${formatAmountWithBaseUnits(
-      loan.repayment.amount,
-      loan.repayment.decimals
-    )} ${loan.repayment.asset} on ${loan.repayment.chain}`,
-    `Current debt: ${formatAmountWithBaseUnits(
-      loan.repayment.debtAmount,
-      loan.repayment.decimals
-    )} ${loan.repayment.asset}`,
-    `Interest buffer: ${formatAmountWithBaseUnits(
+    `Amount to repay: ${formatAmount(loan.repayment.amount, borrowDecimals)} ${
+      loan.repayment.asset
+    } on ${loan.repayment.chain}`,
+    `Current debt: ${formatAmount(loan.repayment.debtAmount, borrowDecimals)} ${
+      loan.repayment.asset
+    }`,
+    `Interest buffer: ${formatAmount(
       loan.repayment.interestBufferAmount,
-      loan.repayment.decimals
-    )} ${loan.repayment.asset} (${loan.repayment.interestBufferSeconds.toString()} seconds)`,
-    `Inflow fee: ${formatAmountWithBaseUnits(
+      borrowDecimals
+    )} ${
+      loan.repayment.asset
+    } (${loan.repayment.interestBufferSeconds.toString()} seconds)`,
+    `Inflow fee: ${formatAmount(
       loan.repayment.inflowFeeAmount,
-      loan.repayment.decimals
+      borrowDecimals
     )} ${loan.repayment.asset}${
       loan.repayment.inflowFeeEstimateAvailable ? "" : " (estimate unavailable)"
     }`,
     "Repay target:",
     formatSupplyTarget(loan.repayment.target),
   ].join("\n");
+}
+
+function getInstantLoanPoolDecimals(
+  pools: Pool[] | undefined,
+  poolId: string,
+  fallbackDecimals: bigint
+): bigint {
+  return (
+    pools?.find((pool) => pool.id === poolId)?.decimals ?? fallbackDecimals
+  );
 }
 
 export function formatActivityStatus(
@@ -224,7 +271,9 @@ export function formatCandidate(candidate: InstantLoanCandidate): string {
     `Loan id: ${candidate.loanId.toString()}`,
     `Profile id: ${candidate.profileId}`,
     `Created at: ${candidate.createdAt?.toISOString() ?? "unknown"}`,
-    `Collateral: ${candidate.collateralAmountHint.toString()} base units of ${candidate.collateralAsset}`,
+    `Collateral: ${candidate.collateralAmountHint.toString()} base units of ${
+      candidate.collateralAsset
+    }`,
     `Borrow asset: ${candidate.borrowAsset}`,
     `Collateral pool: ${candidate.collateralPoolId}`,
     `Borrow pool: ${candidate.borrowPoolId}`,
@@ -245,7 +294,9 @@ function formatActivity(activity: Activity): string {
     `Txid: ${activity.txid ?? "not set"}`,
     `Txids: ${activity.txids?.join(", ") ?? "not set"}`,
     `Confirmations: ${activity.confirmations?.toString() ?? "not set"}`,
-    `Required confirmations: ${activity.requiredConfirmations?.toString() ?? "not set"}`,
+    `Required confirmations: ${
+      activity.requiredConfirmations?.toString() ?? "not set"
+    }`,
     activity.topUp
       ? formatActivityTopUp(activity.topUp)
       : "Top-up: not required",
@@ -374,10 +425,6 @@ function formatInstantLoanAccount(
   }
 
   return `Native principal: ${account.principal}`;
-}
-
-function formatAmountWithBaseUnits(amount: bigint, decimals: bigint): string {
-  return `${formatAmount(amount, decimals)} (${amount.toString()} base units)`;
 }
 
 function formatBytes(bytes: Uint8Array): string {

--- a/examples/instant-loans-flow/src/format.ts
+++ b/examples/instant-loans-flow/src/format.ts
@@ -159,34 +159,23 @@ export function formatInstantLoan(
     loan.borrow.poolId,
     loan.borrow.decimals
   );
-  const repaymentLines = loan.repayment
-    ? [
-        `Amount to repay: ${formatAmount(
-          loan.repayment.amount,
-          borrowDecimals
-        )} ${loan.repayment.asset} on ${loan.repayment.chain}`,
-        `Current debt: ${formatAmount(
-          loan.repayment.debtAmount,
-          borrowDecimals
-        )} ${loan.repayment.asset}`,
-        `Interest buffer: ${formatAmount(
-          loan.repayment.interestBufferAmount,
-          borrowDecimals
-        )} ${
-          loan.repayment.asset
-        } (${loan.repayment.interestBufferSeconds.toString()} seconds)`,
-        `Inflow fee: ${formatAmount(
-          loan.repayment.inflowFeeAmount,
-          borrowDecimals
-        )} ${loan.repayment.asset}${
-          loan.repayment.inflowFeeEstimateAvailable
-            ? ""
-            : " (estimate unavailable)"
-        }`,
-        "Repay target:",
-        formatSupplyTarget(loan.repayment.target),
-      ]
-    : ["No repayment due."];
+  const repaymentLines = [
+    `Amount to repay: ${formatAmount(loan.repayment.amount, borrowDecimals)} ${
+      loan.repayment.asset
+    } on ${loan.repayment.chain}`,
+    `Current debt: ${formatAmount(loan.repayment.debtAmount, borrowDecimals)} ${
+      loan.repayment.asset
+    }`,
+    `Interest buffer: ${formatAmount(
+      loan.repayment.interestBufferAmount,
+      borrowDecimals
+    )} ${loan.repayment.asset} (${loan.repayment.interestBufferSeconds.toString()} seconds)`,
+    `Inflow fee: ${formatAmount(loan.repayment.inflowFeeAmount, borrowDecimals)} ${
+      loan.repayment.asset
+    }${loan.repayment.inflowFeeEstimateAvailable ? "" : " (estimate unavailable)"}`,
+    "Repay target:",
+    formatSupplyTarget(loan.repayment.target),
+  ];
 
   return [
     `Reference: ${loan.ref}`,
@@ -280,7 +269,7 @@ export function formatCandidate(candidate: InstantLoanCandidate): string {
     `Loan id: ${candidate.loanId.toString()}`,
     `Profile id: ${candidate.profileId}`,
     `Created at: ${candidate.createdAt?.toISOString() ?? "unknown"}`,
-    `Collateral: ${candidate.collateralAmountHint.toString()} base units of ${
+    `Collateral: ${candidate.collateralAmount.toString()} base units of ${
       candidate.collateralAsset
     }`,
     `Borrow asset: ${candidate.borrowAsset}`,

--- a/examples/instant-loans-flow/src/format.ts
+++ b/examples/instant-loans-flow/src/format.ts
@@ -152,21 +152,49 @@ export function formatInstantLoan(
   const collateralDecimals = getInstantLoanPoolDecimals(
     options.pools,
     loan.collateral.poolId,
-    loan.position.collateralDecimals
+    loan.collateral.decimals
   );
   const borrowDecimals = getInstantLoanPoolDecimals(
     options.pools,
     loan.borrow.poolId,
-    loan.repayment.decimals
+    loan.borrow.decimals
   );
+  const repaymentLines = loan.repayment
+    ? [
+        `Amount to repay: ${formatAmount(
+          loan.repayment.amount,
+          borrowDecimals
+        )} ${loan.repayment.asset} on ${loan.repayment.chain}`,
+        `Current debt: ${formatAmount(
+          loan.repayment.debtAmount,
+          borrowDecimals
+        )} ${loan.repayment.asset}`,
+        `Interest buffer: ${formatAmount(
+          loan.repayment.interestBufferAmount,
+          borrowDecimals
+        )} ${
+          loan.repayment.asset
+        } (${loan.repayment.interestBufferSeconds.toString()} seconds)`,
+        `Inflow fee: ${formatAmount(
+          loan.repayment.inflowFeeAmount,
+          borrowDecimals
+        )} ${loan.repayment.asset}${
+          loan.repayment.inflowFeeEstimateAvailable
+            ? ""
+            : " (estimate unavailable)"
+        }`,
+        "Repay target:",
+        formatSupplyTarget(loan.repayment.target),
+      ]
+    : ["No repayment due."];
 
   return [
     `Reference: ${loan.ref}`,
     `Loan id: ${loan.loanId.toString()}`,
     `Status: ${loan.status}`,
     `Profile id: ${loan.profileId}`,
-    `Max LTV: ${formatPercentFromBps(loan.ltvMaxBps)}`,
-    `Deposit window seconds: ${loan.depositWindowSeconds.toString()}`,
+    `Max LTV: ${formatPercentFromBps(loan.terms.ltvMaxBps)}`,
+    `Deposit window seconds: ${loan.terms.depositWindowSeconds.toString()}`,
     "",
     "Collateral:",
     `${formatAmount(loan.collateral.amount, collateralDecimals)} ${
@@ -184,7 +212,7 @@ export function formatInstantLoan(
     `Refund destination: ${formatInstantLoanAccount(loan.refundDestination)}`,
     "",
     "Deposit target:",
-    formatSupplyTarget(loan.depositTarget),
+    formatSupplyTarget(loan.initialDeposit.target),
     "",
     "Initial deposit quote:",
     `Amount to send: ${formatAmount(
@@ -222,26 +250,7 @@ export function formatInstantLoan(
     )} ${loan.borrow.asset}`,
     "",
     "Repayment quote:",
-    `Amount to repay: ${formatAmount(loan.repayment.amount, borrowDecimals)} ${
-      loan.repayment.asset
-    } on ${loan.repayment.chain}`,
-    `Current debt: ${formatAmount(loan.repayment.debtAmount, borrowDecimals)} ${
-      loan.repayment.asset
-    }`,
-    `Interest buffer: ${formatAmount(
-      loan.repayment.interestBufferAmount,
-      borrowDecimals
-    )} ${
-      loan.repayment.asset
-    } (${loan.repayment.interestBufferSeconds.toString()} seconds)`,
-    `Inflow fee: ${formatAmount(
-      loan.repayment.inflowFeeAmount,
-      borrowDecimals
-    )} ${loan.repayment.asset}${
-      loan.repayment.inflowFeeEstimateAvailable ? "" : " (estimate unavailable)"
-    }`,
-    "Repay target:",
-    formatSupplyTarget(loan.repayment.target),
+    ...repaymentLines,
   ].join("\n");
 }
 

--- a/examples/instant-loans-flow/src/status.ts
+++ b/examples/instant-loans-flow/src/status.ts
@@ -15,6 +15,7 @@ import {
   findInstantLoansByAddress,
   getInstantLoan,
   getLoanActivityStatus,
+  loadMarketData,
 } from "./sdk-example";
 
 const sdkConfig = getElement<HTMLDivElement>("sdk-config");
@@ -52,18 +53,21 @@ async function loadLoan(): Promise<void> {
   setStatus("Loading loan status...");
   loanOutput.textContent = "Loading loan...";
 
-  const loan = ref
-    ? await getInstantLoan({ ref })
-    : await getInstantLoan({
-        loanId: parsePositiveBigInt(loanIdText, "Loan id"),
-      });
+  const [loan, marketData] = await Promise.all([
+    ref
+      ? getInstantLoan({ ref })
+      : getInstantLoan({
+          loanId: parsePositiveBigInt(loanIdText, "Loan id"),
+        }),
+    loadMarketData(),
+  ]);
 
   loanRefInput.value = loan.ref;
   loanIdInput.value = loan.loanId.toString();
   saveRecentLoanRef(loan.ref);
   refreshRecentLoans();
 
-  loanOutput.textContent = formatInstantLoan(loan);
+  loanOutput.textContent = formatInstantLoan(loan, { pools: marketData.pools });
   setStatus(`Loaded instant loan ${loan.ref}.`);
 }
 

--- a/examples/instant-loans-flow/vite.config.ts
+++ b/examples/instant-loans-flow/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolveProjectPath("./src"),
+      "@liquidium/client": resolveProjectPath(
+        "../../packages/client/src/index.ts"
+      ),
     },
   },
   build: {
@@ -29,5 +32,8 @@ export default defineConfig({
         warn(warning);
       },
     },
+  },
+  optimizeDeps: {
+    exclude: ["@liquidium/client"],
   },
 });

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -211,8 +211,8 @@ Most instant-loan UIs show or store these fields:
 | `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
-| `loan.repayment?.amount` | Full amount to repay, including fee and interest buffer, when debt exists |
-| `loan.repayment?.target` | Address or ICRC account where the user sends repayment, when debt exists |
+| `loan.repayment.amount` | Full amount to repay, including fee and interest buffer. Zero when no repayment is due |
+| `loan.repayment.target` | Address or ICRC account where the user sends repayment |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |
 
 ## Amounts

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -111,12 +111,8 @@ const restoredLoan = await client.instantLoans.get({ ref: loan.ref });
 
 console.log("Loan status:", restoredLoan.status);
 console.log("Restored initial deposit amount:", restoredLoan.initialDeposit.amount.toString());
-if (restoredLoan.repayment) {
-  console.log("Repay amount:", restoredLoan.repayment.amount.toString());
-  console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
-} else {
-  console.log("No repayment due yet.");
-}
+console.log("Repay amount:", restoredLoan.repayment.amount.toString());
+console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
 
 const activities = await client.activities.list({ shortRef: loan.ref });
 
@@ -155,9 +151,9 @@ Instant-loan integrations use this sequence:
 | Validate amounts | `client.quote.calculateLtv(...)` | Block invalid LTV or frozen-pool input before creating a loan |
 | Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.initialDeposit.target` |
 | Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state, initial deposit quote, and repayment activity |
-| Repay loan | Read `loan.repayment` | If non-null, ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
+| Repay loan | Read `loan.repayment` | Ask the user to send `loan.repayment.amount` to `loan.repayment.target`; amount is `0n` when no repayment is due |
 
-`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, current position state, an initial deposit quote with its transfer target, and a nullable repayment quote with its transfer target. Users do not manage the generated profile.
+`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, current position state, an initial deposit quote with its transfer target, and a repayment quote with its transfer target. Repayment amount fields are zero when the loan has no debt. Users do not manage the generated profile.
 
 ## Core API
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -104,11 +104,13 @@ const loan = await client.instantLoans.create({
 });
 
 console.log("Save this loan reference:", loan.ref);
+console.log("Send initial deposit amount:", loan.initialDeposit.amount.toString());
 console.log("Send collateral to:", formatSupplyTarget(loan.depositTarget));
 
 const restoredLoan = await client.instantLoans.get({ ref: loan.ref });
 
 console.log("Loan status:", restoredLoan.status);
+console.log("Restored initial deposit amount:", restoredLoan.initialDeposit.amount.toString());
 console.log("Repay amount:", restoredLoan.repayment.amount.toString());
 console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
 
@@ -147,11 +149,11 @@ Instant-loan integrations use this sequence:
 | --- | --- | --- |
 | Load market data | `client.market.listPools()` and `client.market.getAssetPrices()` | Show supported collateral and borrow assets |
 | Validate amounts | `client.quote.calculateLtv(...)` | Block invalid LTV or frozen-pool input before creating a loan |
-| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.depositTarget` |
-| Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state and monitor deposit, borrow, and repayment activity |
+| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.depositTarget` |
+| Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state, initial deposit quote, and repayment activity |
 | Repay loan | Read `loan.repayment` | Ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
 
-`client.instantLoans.create(...)` returns the generated Liquidium profile, transfer targets, current position state, and repayment quote. Users do not manage the generated profile.
+`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, transfer targets, current position state, an initial deposit quote, and a repayment quote. Users do not manage the generated profile.
 
 ## Core API
 
@@ -165,7 +167,7 @@ Creates an accountless instant loan and returns generated transfer targets.
 | `borrowPoolId` | Pool the loan borrows from |
 | `collateralAsset` | Collateral asset symbol, for example `"BTC"` |
 | `borrowAsset` | Borrow asset symbol, for example `"USDC"` |
-| `collateralAmount` | Collateral amount in base units |
+| `collateralAmount` | Intended credited collateral amount in base units, before deposit/inflow fees |
 | `borrowAmount` | Borrow amount in base units |
 | `ltvMaxBps` | Maximum LTV in basis points, where `6_000n` is 60% |
 | `depositWindowSeconds` | How long the user has to send collateral |
@@ -178,7 +180,7 @@ Creates an accountless instant loan and returns generated transfer targets.
 
 Loads loan state from a saved user-facing reference.
 
-Use this for status pages, refreshes, and support links.
+Use this for status pages, refreshes, and support links. The SDK combines canister state with the Liquidium SDK API lookup so the restored loan includes the original collateral deposit hint.
 
 ### `client.instantLoans.get({ loanId })`
 
@@ -206,6 +208,8 @@ Most instant-loan UIs show or store these fields:
 | --- | --- |
 | `loan.ref` | Save and show this reference so the loan can be restored later |
 | `loan.status` | Show the lifecycle: `awaiting_deposit`, `deposit_detected`, `active`, `settling`, or `closed` |
+| `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
+| `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.depositTarget` | Address or ICRC account where the user sends collateral |
 | `loan.repayment.amount` | Full amount to repay, including fee and interest buffer |
 | `loan.repayment.target` | Address or ICRC account where the user sends repayment |

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -105,14 +105,18 @@ const loan = await client.instantLoans.create({
 
 console.log("Save this loan reference:", loan.ref);
 console.log("Send initial deposit amount:", loan.initialDeposit.amount.toString());
-console.log("Send collateral to:", formatSupplyTarget(loan.depositTarget));
+console.log("Send collateral to:", formatSupplyTarget(loan.initialDeposit.target));
 
 const restoredLoan = await client.instantLoans.get({ ref: loan.ref });
 
 console.log("Loan status:", restoredLoan.status);
 console.log("Restored initial deposit amount:", restoredLoan.initialDeposit.amount.toString());
-console.log("Repay amount:", restoredLoan.repayment.amount.toString());
-console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
+if (restoredLoan.repayment) {
+  console.log("Repay amount:", restoredLoan.repayment.amount.toString());
+  console.log("Repay target:", formatSupplyTarget(restoredLoan.repayment.target));
+} else {
+  console.log("No repayment due yet.");
+}
 
 const activities = await client.activities.list({ shortRef: loan.ref });
 
@@ -149,11 +153,11 @@ Instant-loan integrations use this sequence:
 | --- | --- | --- |
 | Load market data | `client.market.listPools()` and `client.market.getAssetPrices()` | Show supported collateral and borrow assets |
 | Validate amounts | `client.quote.calculateLtv(...)` | Block invalid LTV or frozen-pool input before creating a loan |
-| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.depositTarget` |
+| Create loan | `client.instantLoans.create(...)` | Store `loan.ref` and show `loan.initialDeposit.amount` plus `loan.initialDeposit.target` |
 | Track loan | `client.instantLoans.get({ ref })` and `client.activities.list({ shortRef: ref })` | Reload loan state, initial deposit quote, and repayment activity |
-| Repay loan | Read `loan.repayment` | Ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
+| Repay loan | Read `loan.repayment` | If non-null, ask the user to send `loan.repayment.amount` to `loan.repayment.target` |
 
-`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, transfer targets, current position state, an initial deposit quote, and a repayment quote. Users do not manage the generated profile.
+`client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, current position state, an initial deposit quote with its transfer target, and a nullable repayment quote with its transfer target. Users do not manage the generated profile.
 
 ## Core API
 
@@ -207,12 +211,12 @@ Most instant-loan UIs show or store these fields:
 | Field | Use |
 | --- | --- |
 | `loan.ref` | Save and show this reference so the loan can be restored later |
-| `loan.status` | Show the lifecycle: `awaiting_deposit`, `deposit_detected`, `active`, `settling`, or `closed` |
+| `loan.status` | Show the lifecycle: `awaiting_deposit`, `deposit_detected`, `active`, `settling`, `closed`, or `expired` |
 | `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
-| `loan.depositTarget` | Address or ICRC account where the user sends collateral |
-| `loan.repayment.amount` | Full amount to repay, including fee and interest buffer |
-| `loan.repayment.target` | Address or ICRC account where the user sends repayment |
+| `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
+| `loan.repayment?.amount` | Full amount to repay, including fee and interest buffer, when debt exists |
+| `loan.repayment?.target` | Address or ICRC account where the user sends repayment, when debt exists |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |
 
 ## Amounts
@@ -224,7 +228,7 @@ The SDK returns amount fields as `bigint` values in the asset's smallest unit.
 | BTC | Satoshis |
 | USDC / USDT | Token base units using the pool decimals |
 
-Use `Pool.decimals` from `client.market.listPools()` when converting user-entered decimals to base units.
+Use `Pool.decimals` from `client.market.listPools()` when converting user-entered decimals to base units. Hydrated instant loans also include `loan.collateral.decimals`, `loan.borrow.decimals`, and `loan.initialDeposit.decimals` for display.
 
 ## Status And Activity Tracking
 

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4184,23 +4184,27 @@ describe("InstantLoansModule", () => {
     expect(loan.profileId).toBe(PROFILE_ID);
     expect(loan).not.toHaveProperty("started");
     expect(loan).not.toHaveProperty("depositDetectedTimestamp");
-    expect(loan.ltvMaxBps).toBe(6_800n);
+    expect(loan.terms).toEqual({
+      ltvMaxBps: 6_800n,
+      depositWindowSeconds: 3_600n,
+    });
     expect(loan.collateral).toMatchObject({
       poolId: BTC_POOL_ID,
       asset: "BTC",
       chain: "BTC",
+      decimals: 8n,
       amount: 10_000_000n,
     });
     expect(loan.collateral).not.toHaveProperty("amountHint");
-    expect(loan.borrow.amount).toBe(2_000_000n);
-    expect(loan.depositTarget).toMatchObject({
-      type: "nativeAddress",
-      asset: "BTC",
-      chain: "BTC",
-      address: "bc1qinstantdeposit",
+    expect(loan.borrow).toMatchObject({
+      amount: 2_000_000n,
+      decimals: 6n,
     });
+    expect(loan).not.toHaveProperty("depositTarget");
+    expect(loan).not.toHaveProperty("repayTarget");
     expect(loan.initialDeposit).toMatchObject({
       amount: 10_002_010n,
+      decimals: 8n,
       collateralAmount: 10_000_000n,
       inflowFeeAmount: 2_010n,
       asset: "BTC",
@@ -4208,12 +4212,6 @@ describe("InstantLoansModule", () => {
       target: expect.objectContaining({
         address: "bc1qinstantdeposit",
       }),
-    });
-    expect(loan.repayTarget).toMatchObject({
-      type: "nativeAddress",
-      asset: "USDT",
-      chain: "ETH",
-      address: "0x1111111111111111111111111111111111111111",
     });
     expect(loan.repayment).toMatchObject({
       amount: 3_501_054n,
@@ -4225,6 +4223,12 @@ describe("InstantLoansModule", () => {
       inflowFeeEstimateAvailable: true,
       asset: "USDT",
       chain: "ETH",
+      target: expect.objectContaining({
+        type: "nativeAddress",
+        asset: "USDT",
+        chain: "ETH",
+        address: "0x1111111111111111111111111111111111111111",
+      }),
     });
     expect(loan.position).toMatchObject({
       collateralAmount: 10_000_000n,
@@ -4309,6 +4313,7 @@ describe("InstantLoansModule", () => {
     // then
     expect(loan.repayment).toMatchObject({
       amount: 1_002_537n,
+      decimals: 8n,
       debtAmount: 1_000_500n,
       interestBufferAmount: 27n,
       inflowFeeAmount: 2_010n,
@@ -4318,6 +4323,7 @@ describe("InstantLoansModule", () => {
     });
     expect(loan.initialDeposit).toMatchObject({
       amount: 6_500_000n,
+      decimals: 6n,
       collateralAmount: 5_000_000n,
       inflowFeeAmount: 1_500_000n,
       asset: "USDT",
@@ -4412,7 +4418,7 @@ describe("InstantLoansModule", () => {
     ]);
   });
 
-  test("returns zero repayment quote when the loan has no debt", async () => {
+  test("returns null repayment quote when the loan has no debt", async () => {
     // given
     const getLoan = vi.fn().mockResolvedValue({ Ok: createInstantLoan() });
     const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
@@ -4459,15 +4465,70 @@ describe("InstantLoansModule", () => {
     });
 
     // then
-    expect(loan.repayment).toMatchObject({
-      amount: 0n,
-      debtAmount: 0n,
-      interestBufferAmount: 0n,
-      inflowFeeAmount: 0n,
-      inflowFeeEstimateAvailable: false,
-    });
+    expect(loan.repayment).toBeNull();
     expect(loan.initialDeposit.amount).toBe(10_002_010n);
     expect(loan.status).toBe("awaiting_deposit");
+    expect(estimateDepositFee).not.toHaveBeenCalled();
+  });
+
+  test("returns expired status when the deposit window passed before collateral arrived", async () => {
+    // given
+    const ONE_SECOND_MS = 1_000;
+    const NANOSECONDS_PER_MILLISECOND = 1_000_000n;
+    const EXPIRED_DEPOSIT_TIMESTAMP_NS =
+      BigInt(Date.now() - ONE_SECOND_MS) * NANOSECONDS_PER_MILLISECOND;
+    const getLoan = vi.fn().mockResolvedValue({
+      Ok: {
+        ...createInstantLoan(),
+        expires_at: [EXPIRED_DEPOSIT_TIMESTAMP_NS],
+      },
+    });
+    const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
+    const getDepositAddress = vi.fn().mockResolvedValue({
+      Ok: "0x1111111111111111111111111111111111111111",
+    });
+    const getPoolRate = vi
+      .fn()
+      .mockResolvedValue([[10_000_000_000_000_000_000_000_000n, 0n, 0n]]);
+    const estimateDepositFee = vi.fn().mockResolvedValue({ Ok: 1_500_000n });
+    const getDepositFee = vi.fn().mockResolvedValue(2_000n);
+    const icrc1Fee = vi.fn().mockResolvedValue(10n);
+    mockInstantLoanLookupFetch({
+      collateralAmountHint: "10000000",
+    });
+
+    vi.spyOn(Actor, "createActor")
+      .mockReturnValueOnce({ get_loan: getLoan } as never)
+      .mockReturnValueOnce({
+        list_pools: vi.fn().mockResolvedValue([createBtcPoolRecord()]),
+      } as never)
+      .mockReturnValueOnce({
+        list_pools: vi.fn().mockResolvedValue([createUsdtPoolRecord()]),
+      } as never)
+      .mockReturnValueOnce({
+        get_position: vi.fn().mockResolvedValue([]),
+      } as never)
+      .mockReturnValueOnce({
+        get_position: vi.fn().mockResolvedValue([]),
+      } as never)
+      .mockReturnValueOnce({ get_pool_rate: getPoolRate } as never)
+      .mockReturnValueOnce({ get_btc_address: getBtcAddress } as never)
+      .mockReturnValueOnce({ get_deposit_address: getDepositAddress } as never)
+      .mockReturnValueOnce({ get_deposit_fee: getDepositFee } as never)
+      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never);
+    const client = new LiquidiumClient({
+      apiBaseUrl: "https://app.liquidium.fi/api/sdk",
+      canisterIds: { instantLoans: "kzrva-ziaaa-aaaar-qamyq-cai" },
+    });
+
+    // when
+    const loan = await client.instantLoans.get({
+      ref: publicIdFromInt(LOAN_ID),
+    });
+
+    // then
+    expect(loan.status).toBe("expired");
+    expect(loan.repayment).toBeNull();
     expect(estimateDepositFee).not.toHaveBeenCalled();
   });
 
@@ -4604,8 +4665,14 @@ describe("InstantLoansModule", () => {
     expect(loan.loanId).toBe(LOAN_ID);
     expect(loan.status).toBe("awaiting_deposit");
     expect(loan.collateral.amount).toBe(10_000_000n);
+    expect(loan.terms).toEqual({
+      ltvMaxBps: 6_800n,
+      depositWindowSeconds: 3_600n,
+    });
+    expect(loan.repayment).toBeNull();
     expect(loan.initialDeposit).toMatchObject({
       amount: EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS,
+      decimals: 8n,
       collateralAmount: 10_000_000n,
       inflowFeeAmount: BTC_MINTER_DEPOSIT_FEE_SATS + CKBTC_LEDGER_FEE_SATS,
       asset: "BTC",

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4122,7 +4122,7 @@ describe("InstantLoansModule", () => {
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
     const fetchSpy = mockInstantLoanLookupFetch({
-      collateralAmountHint: "10000000",
+      collateralAmount: "10000000",
     });
     const getCollateralPosition = vi.fn().mockResolvedValue([
       createInstantLoanPosition(
@@ -4175,7 +4175,7 @@ describe("InstantLoansModule", () => {
     // then
     expect(getLoan).toHaveBeenCalledWith(LOAN_ID);
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${DEFAULT_API_BASE_URL}/v1/instant-loans/${LOAN_ID.toString()}/collateral-hint`,
+      `${DEFAULT_API_BASE_URL}/v1/instant-loans/${LOAN_ID.toString()}/collateral-amount`,
       expect.objectContaining({ method: "GET" })
     );
     expect(loan.loanId).toBe(LOAN_ID);
@@ -4195,7 +4195,6 @@ describe("InstantLoansModule", () => {
       decimals: 8n,
       amount: 10_000_000n,
     });
-    expect(loan.collateral).not.toHaveProperty("amountHint");
     expect(loan.borrow).toMatchObject({
       amount: 2_000_000n,
       decimals: 6n,
@@ -4277,7 +4276,7 @@ describe("InstantLoansModule", () => {
     mockInstantLoanLookupFetch({
       borrowAsset: "BTC",
       borrowPoolId: BTC_POOL_ID,
-      collateralAmountHint: "5000000",
+      collateralAmount: "5000000",
       collateralAsset: "USDT",
       collateralPoolId: USDT_POOL_ID,
     });
@@ -4418,7 +4417,7 @@ describe("InstantLoansModule", () => {
     ]);
   });
 
-  test("returns null repayment quote when the loan has no debt", async () => {
+  test("returns zero repayment quote when the loan has no debt", async () => {
     // given
     const getLoan = vi.fn().mockResolvedValue({ Ok: createInstantLoan() });
     const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
@@ -4432,7 +4431,7 @@ describe("InstantLoansModule", () => {
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
     mockInstantLoanLookupFetch({
-      collateralAmountHint: "10000000",
+      collateralAmount: "10000000",
     });
 
     vi.spyOn(Actor, "createActor")
@@ -4465,7 +4464,15 @@ describe("InstantLoansModule", () => {
     });
 
     // then
-    expect(loan.repayment).toBeNull();
+    expect(loan.repayment).toMatchObject({
+      amount: 0n,
+      debtAmount: 0n,
+      interestBufferAmount: 0n,
+      inflowFeeAmount: 0n,
+      inflowFeeEstimateAvailable: false,
+      asset: "USDT",
+      chain: "ETH",
+    });
     expect(loan.initialDeposit.amount).toBe(10_002_010n);
     expect(loan.status).toBe("awaiting_deposit");
     expect(estimateDepositFee).not.toHaveBeenCalled();
@@ -4494,7 +4501,7 @@ describe("InstantLoansModule", () => {
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
     mockInstantLoanLookupFetch({
-      collateralAmountHint: "10000000",
+      collateralAmount: "10000000",
     });
 
     vi.spyOn(Actor, "createActor")
@@ -4528,7 +4535,15 @@ describe("InstantLoansModule", () => {
 
     // then
     expect(loan.status).toBe("expired");
-    expect(loan.repayment).toBeNull();
+    expect(loan.repayment).toMatchObject({
+      amount: 0n,
+      debtAmount: 0n,
+      interestBufferAmount: 0n,
+      inflowFeeAmount: 0n,
+      inflowFeeEstimateAvailable: false,
+      asset: "USDT",
+      chain: "ETH",
+    });
     expect(estimateDepositFee).not.toHaveBeenCalled();
   });
 
@@ -4549,7 +4564,7 @@ describe("InstantLoansModule", () => {
             collateral: {
               poolId: BTC_POOL_ID,
               asset: "BTC",
-              amountHint: "10000000",
+              amount: "10000000",
             },
             borrow: {
               poolId: USDT_POOL_ID,
@@ -4669,7 +4684,15 @@ describe("InstantLoansModule", () => {
       ltvMaxBps: 6_800n,
       depositWindowSeconds: 3_600n,
     });
-    expect(loan.repayment).toBeNull();
+    expect(loan.repayment).toMatchObject({
+      amount: 0n,
+      debtAmount: 0n,
+      interestBufferAmount: 0n,
+      inflowFeeAmount: 0n,
+      inflowFeeEstimateAvailable: false,
+      asset: "USDT",
+      chain: "ETH",
+    });
     expect(loan.initialDeposit).toMatchObject({
       amount: EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS,
       decimals: 8n,
@@ -4947,7 +4970,7 @@ describe("InstantLoansModule", () => {
               borrow_pool_ic_id: USDT_POOL_ID,
               lend_asset: "BTC",
               borrow_asset: "USDT",
-              min_deposit_hint: "10000000",
+              collateralAmount: "10000000",
             },
           ],
         }),
@@ -4968,6 +4991,7 @@ describe("InstantLoansModule", () => {
         ref: publicIdFromInt(LOAN_ID),
         profileId: PROFILE_ID,
         collateralAsset: "BTC",
+        collateralAmount: 10_000_000n,
         borrowAsset: "USDT",
       }),
     ]);
@@ -5011,7 +5035,7 @@ describe("InstantLoansModule", () => {
     overrides: Partial<{
       borrowAsset: string;
       borrowPoolId: string;
-      collateralAmountHint: string;
+      collateralAmount: string;
       collateralAsset: string;
       collateralPoolId: string;
     }> = {}
@@ -5020,7 +5044,7 @@ describe("InstantLoansModule", () => {
       new Response(
         JSON.stringify({
           success: true,
-          collateralAmountHint: overrides.collateralAmountHint ?? "10000000",
+          collateralAmount: overrides.collateralAmount ?? "10000000",
         }),
         { status: 200, headers: { "content-type": "application/json" } }
       )

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4122,7 +4122,7 @@ describe("InstantLoansModule", () => {
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
     const fetchSpy = mockInstantLoanLookupFetch({
-      collateralAmount: "10000000",
+      collateralAmountHint: "10000000",
     });
     const getCollateralPosition = vi.fn().mockResolvedValue([
       createInstantLoanPosition(
@@ -4175,7 +4175,7 @@ describe("InstantLoansModule", () => {
     // then
     expect(getLoan).toHaveBeenCalledWith(LOAN_ID);
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${DEFAULT_API_BASE_URL}/v1/instant-loans/${LOAN_ID.toString()}/collateral-amount`,
+      `${DEFAULT_API_BASE_URL}/v1/instant-loans/${LOAN_ID.toString()}/collateral-hint`,
       expect.objectContaining({ method: "GET" })
     );
     expect(loan.loanId).toBe(LOAN_ID);
@@ -4276,7 +4276,7 @@ describe("InstantLoansModule", () => {
     mockInstantLoanLookupFetch({
       borrowAsset: "BTC",
       borrowPoolId: BTC_POOL_ID,
-      collateralAmount: "5000000",
+      collateralAmountHint: "5000000",
       collateralAsset: "USDT",
       collateralPoolId: USDT_POOL_ID,
     });
@@ -4431,7 +4431,7 @@ describe("InstantLoansModule", () => {
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
     mockInstantLoanLookupFetch({
-      collateralAmount: "10000000",
+      collateralAmountHint: "10000000",
     });
 
     vi.spyOn(Actor, "createActor")
@@ -4492,7 +4492,7 @@ describe("InstantLoansModule", () => {
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
     mockInstantLoanLookupFetch({
-      collateralAmount: "10000000",
+      collateralAmountHint: "10000000",
     });
 
     vi.spyOn(Actor, "createActor")
@@ -4555,7 +4555,7 @@ describe("InstantLoansModule", () => {
             collateral: {
               poolId: BTC_POOL_ID,
               asset: "BTC",
-              amount: "10000000",
+              amountHint: "10000000",
             },
             borrow: {
               poolId: USDT_POOL_ID,
@@ -5026,7 +5026,7 @@ describe("InstantLoansModule", () => {
     overrides: Partial<{
       borrowAsset: string;
       borrowPoolId: string;
-      collateralAmount: string;
+      collateralAmountHint: string;
       collateralAsset: string;
       collateralPoolId: string;
     }> = {}
@@ -5035,7 +5035,7 @@ describe("InstantLoansModule", () => {
       new Response(
         JSON.stringify({
           success: true,
-          collateralAmount: overrides.collateralAmount ?? "10000000",
+          collateralAmountHint: overrides.collateralAmountHint ?? "10000000",
         }),
         { status: 200, headers: { "content-type": "application/json" } }
       )

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4478,18 +4478,9 @@ describe("InstantLoansModule", () => {
     expect(estimateDepositFee).not.toHaveBeenCalled();
   });
 
-  test("returns expired status when the deposit window passed before collateral arrived", async () => {
+  test("returns awaiting deposit status when collateral has not arrived", async () => {
     // given
-    const ONE_SECOND_MS = 1_000;
-    const NANOSECONDS_PER_MILLISECOND = 1_000_000n;
-    const EXPIRED_DEPOSIT_TIMESTAMP_NS =
-      BigInt(Date.now() - ONE_SECOND_MS) * NANOSECONDS_PER_MILLISECOND;
-    const getLoan = vi.fn().mockResolvedValue({
-      Ok: {
-        ...createInstantLoan(),
-        expires_at: [EXPIRED_DEPOSIT_TIMESTAMP_NS],
-      },
-    });
+    const getLoan = vi.fn().mockResolvedValue({ Ok: createInstantLoan() });
     const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
     const getDepositAddress = vi.fn().mockResolvedValue({
       Ok: "0x1111111111111111111111111111111111111111",
@@ -4534,7 +4525,7 @@ describe("InstantLoansModule", () => {
     });
 
     // then
-    expect(loan.status).toBe("expired");
+    expect(loan.status).toBe("awaiting_deposit");
     expect(loan.repayment).toMatchObject({
       amount: 0n,
       debtAmount: 0n,

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4119,6 +4119,11 @@ describe("InstantLoansModule", () => {
       .fn()
       .mockResolvedValue([[10_000_000_000_000_000_000_000_000n, 0n, 0n]]);
     const estimateDepositFee = vi.fn().mockResolvedValue({ Ok: 1_500_000n });
+    const getDepositFee = vi.fn().mockResolvedValue(2_000n);
+    const icrc1Fee = vi.fn().mockResolvedValue(10n);
+    const fetchSpy = mockInstantLoanLookupFetch({
+      collateralAmountHint: "10000000",
+    });
     const getCollateralPosition = vi.fn().mockResolvedValue([
       createInstantLoanPosition(
         BTC_POOL_ID,
@@ -4154,7 +4159,9 @@ describe("InstantLoansModule", () => {
       .mockReturnValueOnce({ get_deposit_address: getDepositAddress } as never)
       .mockReturnValueOnce({
         estimate_deposit_fee: estimateDepositFee,
-      } as never);
+      } as never)
+      .mockReturnValueOnce({ get_deposit_fee: getDepositFee } as never)
+      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never);
     const client = new LiquidiumClient({
       apiBaseUrl: "https://app.liquidium.fi/api/sdk",
       canisterIds: { instantLoans: "kzrva-ziaaa-aaaar-qamyq-cai" },
@@ -4167,6 +4174,10 @@ describe("InstantLoansModule", () => {
 
     // then
     expect(getLoan).toHaveBeenCalledWith(LOAN_ID);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${DEFAULT_API_BASE_URL}/v1/instant-loans/${LOAN_ID.toString()}/collateral-hint`,
+      expect.objectContaining({ method: "GET" })
+    );
     expect(loan.loanId).toBe(LOAN_ID);
     expect(loan.ref).toBe(publicIdFromInt(LOAN_ID));
     expect(loan.status).toBe("active");
@@ -4187,6 +4198,16 @@ describe("InstantLoansModule", () => {
       asset: "BTC",
       chain: "BTC",
       address: "bc1qinstantdeposit",
+    });
+    expect(loan.initialDeposit).toMatchObject({
+      amount: 10_002_010n,
+      collateralAmount: 10_000_000n,
+      inflowFeeAmount: 2_010n,
+      asset: "BTC",
+      chain: "BTC",
+      target: expect.objectContaining({
+        address: "bc1qinstantdeposit",
+      }),
     });
     expect(loan.repayTarget).toMatchObject({
       type: "nativeAddress",
@@ -4248,6 +4269,14 @@ describe("InstantLoansModule", () => {
     ]);
     const getDepositFee = vi.fn().mockResolvedValue(2_000n);
     const icrc1Fee = vi.fn().mockResolvedValue(10n);
+    const estimateDepositFee = vi.fn().mockResolvedValue({ Ok: 1_500_000n });
+    mockInstantLoanLookupFetch({
+      borrowAsset: "BTC",
+      borrowPoolId: BTC_POOL_ID,
+      collateralAmountHint: "5000000",
+      collateralAsset: "USDT",
+      collateralPoolId: USDT_POOL_ID,
+    });
 
     vi.spyOn(Actor, "createActor")
       .mockReturnValueOnce({ get_loan: getLoan } as never)
@@ -4263,7 +4292,10 @@ describe("InstantLoansModule", () => {
       .mockReturnValueOnce({ get_deposit_address: getDepositAddress } as never)
       .mockReturnValueOnce({ get_btc_address: getBtcAddress } as never)
       .mockReturnValueOnce({ get_deposit_fee: getDepositFee } as never)
-      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never);
+      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never)
+      .mockReturnValueOnce({
+        estimate_deposit_fee: estimateDepositFee,
+      } as never);
     const client = new LiquidiumClient({
       apiBaseUrl: "https://app.liquidium.fi/api/sdk",
       canisterIds: { instantLoans: "kzrva-ziaaa-aaaar-qamyq-cai" },
@@ -4283,6 +4315,13 @@ describe("InstantLoansModule", () => {
       inflowFeeEstimateAvailable: true,
       asset: "BTC",
       chain: "BTC",
+    });
+    expect(loan.initialDeposit).toMatchObject({
+      amount: 6_500_000n,
+      collateralAmount: 5_000_000n,
+      inflowFeeAmount: 1_500_000n,
+      asset: "USDT",
+      chain: "ETH",
     });
     expect(getDepositFee).toHaveBeenCalledWith();
     expect(icrc1Fee).toHaveBeenCalledWith();
@@ -4384,6 +4423,11 @@ describe("InstantLoansModule", () => {
       .fn()
       .mockResolvedValue([[10_000_000_000_000_000_000_000_000n, 0n, 0n]]);
     const estimateDepositFee = vi.fn().mockResolvedValue({ Ok: 1_500_000n });
+    const getDepositFee = vi.fn().mockResolvedValue(2_000n);
+    const icrc1Fee = vi.fn().mockResolvedValue(10n);
+    mockInstantLoanLookupFetch({
+      collateralAmountHint: "10000000",
+    });
 
     vi.spyOn(Actor, "createActor")
       .mockReturnValueOnce({ get_loan: getLoan } as never)
@@ -4402,9 +4446,8 @@ describe("InstantLoansModule", () => {
       .mockReturnValueOnce({ get_pool_rate: getPoolRate } as never)
       .mockReturnValueOnce({ get_btc_address: getBtcAddress } as never)
       .mockReturnValueOnce({ get_deposit_address: getDepositAddress } as never)
-      .mockReturnValueOnce({
-        estimate_deposit_fee: estimateDepositFee,
-      } as never);
+      .mockReturnValueOnce({ get_deposit_fee: getDepositFee } as never)
+      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never);
     const client = new LiquidiumClient({
       apiBaseUrl: "https://app.liquidium.fi/api/sdk",
       canisterIds: { instantLoans: "kzrva-ziaaa-aaaar-qamyq-cai" },
@@ -4423,12 +4466,15 @@ describe("InstantLoansModule", () => {
       inflowFeeAmount: 0n,
       inflowFeeEstimateAvailable: false,
     });
+    expect(loan.initialDeposit.amount).toBe(10_002_010n);
     expect(loan.status).toBe("awaiting_deposit");
     expect(estimateDepositFee).not.toHaveBeenCalled();
   });
 
   test("creates a loan through the default SDK API without calling the instant-loans canister", async () => {
     // given
+    const BTC_MINTER_DEPOSIT_FEE_SATS = 2_000n;
+    const CKBTC_LEDGER_FEE_SATS = 10n;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -4501,7 +4547,10 @@ describe("InstantLoansModule", () => {
         }),
       } as never)
       .mockReturnValueOnce({
-        estimate_deposit_fee: vi.fn().mockResolvedValue({ Ok: 1_500_000n }),
+        get_deposit_fee: vi.fn().mockResolvedValue(BTC_MINTER_DEPOSIT_FEE_SATS),
+      } as never)
+      .mockReturnValueOnce({
+        icrc1_fee: vi.fn().mockResolvedValue(CKBTC_LEDGER_FEE_SATS),
       } as never);
     const client = new LiquidiumClient({
       canisterIds: { instantLoans: "kzrva-ziaaa-aaaar-qamyq-cai" },
@@ -4525,6 +4574,9 @@ describe("InstantLoansModule", () => {
     });
 
     // then
+    const EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS =
+      10_000_000n + BTC_MINTER_DEPOSIT_FEE_SATS + CKBTC_LEDGER_FEE_SATS;
+
     expect(fetchSpy).toHaveBeenCalledWith(
       `${DEFAULT_API_BASE_URL}/v1/instant-loans`,
       expect.objectContaining({
@@ -4552,6 +4604,16 @@ describe("InstantLoansModule", () => {
     expect(loan.loanId).toBe(LOAN_ID);
     expect(loan.status).toBe("awaiting_deposit");
     expect(loan.collateral.amount).toBe(10_000_000n);
+    expect(loan.initialDeposit).toMatchObject({
+      amount: EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS,
+      collateralAmount: 10_000_000n,
+      inflowFeeAmount: BTC_MINTER_DEPOSIT_FEE_SATS + CKBTC_LEDGER_FEE_SATS,
+      asset: "BTC",
+      chain: "BTC",
+      target: expect.objectContaining({
+        address: "bc1qinstantdeposit",
+      }),
+    });
   });
 
   test("rejects an instant loan with an invalid BTC refund destination", async () => {
@@ -4876,6 +4938,26 @@ describe("InstantLoansModule", () => {
       expires_at: [],
       deposit_detected_ts: [],
     };
+  }
+
+  function mockInstantLoanLookupFetch(
+    overrides: Partial<{
+      borrowAsset: string;
+      borrowPoolId: string;
+      collateralAmountHint: string;
+      collateralAsset: string;
+      collateralPoolId: string;
+    }> = {}
+  ) {
+    return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          collateralAmountHint: overrides.collateralAmountHint ?? "10000000",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
   }
 
   function createBtcBorrowInstantLoan() {

--- a/packages/client/src/core/sdk-api-paths.ts
+++ b/packages/client/src/core/sdk-api-paths.ts
@@ -36,6 +36,10 @@ type BuildInstantLoanAddressLookupPathRequest = {
   address: string;
 };
 
+type BuildInstantLoanCollateralHintPathRequest = {
+  loanId: bigint;
+};
+
 const ACTIVITIES = `/${SDK_API_VERSION.activities}/activities`;
 const HISTORY_POOL = `/${SDK_API_VERSION.history}/history/pool`;
 const HISTORY_POOL_CONFIG = `/${SDK_API_VERSION.history}/history/pool-config`;
@@ -123,6 +127,14 @@ export function buildInstantLoanAddressLookupPath(
 ): string {
   const query = new URLSearchParams({ address: request.address });
   return `${INSTANT_LOANS}/address?${query.toString()}`;
+}
+
+export function buildInstantLoanCollateralHintPath(
+  request: BuildInstantLoanCollateralHintPathRequest
+): string {
+  return `${INSTANT_LOANS}/${encodeURIComponent(
+    request.loanId.toString()
+  )}/collateral-hint`;
 }
 
 export const SdkApiPath = {

--- a/packages/client/src/core/sdk-api-paths.ts
+++ b/packages/client/src/core/sdk-api-paths.ts
@@ -36,7 +36,7 @@ type BuildInstantLoanAddressLookupPathRequest = {
   address: string;
 };
 
-type BuildInstantLoanCollateralAmountPathRequest = {
+type BuildInstantLoanCollateralHintPathRequest = {
   loanId: bigint;
 };
 
@@ -129,12 +129,12 @@ export function buildInstantLoanAddressLookupPath(
   return `${INSTANT_LOANS}/address?${query.toString()}`;
 }
 
-export function buildInstantLoanCollateralAmountPath(
-  request: BuildInstantLoanCollateralAmountPathRequest
+export function buildInstantLoanCollateralHintPath(
+  request: BuildInstantLoanCollateralHintPathRequest
 ): string {
   return `${INSTANT_LOANS}/${encodeURIComponent(
     request.loanId.toString()
-  )}/collateral-amount`;
+  )}/collateral-hint`;
 }
 
 export const SdkApiPath = {

--- a/packages/client/src/core/sdk-api-paths.ts
+++ b/packages/client/src/core/sdk-api-paths.ts
@@ -36,7 +36,7 @@ type BuildInstantLoanAddressLookupPathRequest = {
   address: string;
 };
 
-type BuildInstantLoanCollateralHintPathRequest = {
+type BuildInstantLoanCollateralAmountPathRequest = {
   loanId: bigint;
 };
 
@@ -129,12 +129,12 @@ export function buildInstantLoanAddressLookupPath(
   return `${INSTANT_LOANS}/address?${query.toString()}`;
 }
 
-export function buildInstantLoanCollateralHintPath(
-  request: BuildInstantLoanCollateralHintPathRequest
+export function buildInstantLoanCollateralAmountPath(
+  request: BuildInstantLoanCollateralAmountPathRequest
 ): string {
   return `${INSTANT_LOANS}/${encodeURIComponent(
     request.loanId.toString()
-  )}/collateral-hint`;
+  )}/collateral-amount`;
 }
 
 export const SdkApiPath = {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -106,6 +106,7 @@ export type {
   InstantLoanEvent,
   InstantLoanEventType,
   InstantLoanGetRequest,
+  InstantLoanInitialDeposit,
   InstantLoanLeg,
   InstantLoanListEventsRequest,
   InstantLoanPositionSummary,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -101,7 +101,9 @@ export type {
   InstantLoanAccount,
   InstantLoanAsset,
   InstantLoanAuthorization,
+  InstantLoanBorrow,
   InstantLoanCandidate,
+  InstantLoanCollateral,
   InstantLoanConfig,
   InstantLoanEvent,
   InstantLoanEventType,
@@ -111,6 +113,7 @@ export type {
   InstantLoanListEventsRequest,
   InstantLoanPositionSummary,
   InstantLoanRepayment,
+  InstantLoanTerms,
   InstantLoanWarmedProfile,
   NativeAccount,
 } from "./modules/instant-loans";

--- a/packages/client/src/modules/instant-loans/index.ts
+++ b/packages/client/src/modules/instant-loans/index.ts
@@ -12,6 +12,7 @@ export type {
   InstantLoanEvent,
   InstantLoanEventType,
   InstantLoanGetRequest,
+  InstantLoanInitialDeposit,
   InstantLoanLeg,
   InstantLoanListEventsRequest,
   InstantLoanPositionSummary,

--- a/packages/client/src/modules/instant-loans/index.ts
+++ b/packages/client/src/modules/instant-loans/index.ts
@@ -7,7 +7,9 @@ export type {
   InstantLoanAccount,
   InstantLoanAsset,
   InstantLoanAuthorization,
+  InstantLoanBorrow,
   InstantLoanCandidate,
+  InstantLoanCollateral,
   InstantLoanConfig,
   InstantLoanEvent,
   InstantLoanEventType,
@@ -17,6 +19,7 @@ export type {
   InstantLoanListEventsRequest,
   InstantLoanPositionSummary,
   InstantLoanRepayment,
+  InstantLoanTerms,
   InstantLoanWarmedProfile,
   NativeAccount,
 } from "./types";

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -19,6 +19,7 @@ import {
 import type { ApiClient } from "../../core/transports/api-client";
 import type { CanisterContext } from "../../core/transports/canister-context";
 import { type Asset, type Chain, SupplyAction } from "../../core/types";
+import { getAssetNativeDecimals } from "../../core/utils/asset-decimals";
 import { getVariantKey } from "../../core/utils/variant";
 import { resolveSupplyTarget } from "../lending/_internal/supply-targets";
 import type { LendingModule } from "../lending/lending";
@@ -56,6 +57,7 @@ const RATE_SCALE = 10n ** 27n;
 const SECONDS_PER_YEAR = 31_536_000n;
 const ETH_STABLECOIN_INFLOW_FEE_FALLBACK = 1_500_000n;
 const INSTANT_LOAN_MIN_SLIPPAGE_BUFFER_BPS = 200n;
+const NANOSECONDS_PER_MILLISECOND = 1_000_000n;
 
 type InstantLoanLtvPolicy = {
   ltvBps: bigint;
@@ -111,6 +113,11 @@ type InstantLoanAccountWire =
   | { principal: string; type: "Native" }
   | InstantLoanAccountVariantWire;
 
+type InstantLoanStatusHydrationInput = {
+  collateralAmount: bigint;
+  totalDebtAmount: bigint;
+};
+
 type InstantLoanWire = {
   loanId: string;
   ref?: string;
@@ -144,7 +151,7 @@ type InstantLoanHydrationInput = {
   borrowAmount: bigint;
   borrowDestination: InstantLoanAccount;
   refundDestination: InstantLoanAccount;
-  started?: boolean;
+  deriveStatus: (input: InstantLoanStatusHydrationInput) => InstantLoanStatus;
 };
 
 /** Accountless instant-loan creation, lookup, recovery, and canister query helpers. */
@@ -158,7 +165,7 @@ export class InstantLoansModule {
 
   /**
    * Creates a profileless instant loan and returns canonical canister state plus
-   * deposit/repay targets for the generated lending profile.
+   * generated initial-deposit and repayment quote targets.
    *
    * Choose `collateralPoolId` and `borrowPoolId` from
    * `client.market.listPools()`, convert UI amounts to base units with the
@@ -171,7 +178,7 @@ export class InstantLoansModule {
    * SDK maps it to the canister's internal `ltv_timer_s` field.
    *
    * @param request - Pool ids, assets, base-unit amounts, LTV limit, timeout, and destinations.
-   * @returns Hydrated loan state plus generated targets, initial deposit quote, and repayment quote.
+   * @returns Hydrated loan state plus generated initial-deposit and repayment quote targets.
    */
   async create(request: CreateInstantLoanRequest): Promise<InstantLoan> {
     validateCreateRequest(request);
@@ -217,7 +224,7 @@ export class InstantLoansModule {
    * from the instant-loans canister.
    *
    * @param request - Canister loan id or short public reference.
-   * @returns Hydrated loan state plus generated deposit and repayment targets.
+   * @returns Hydrated loan state plus generated initial-deposit and repayment quote targets.
    */
   async get(request: InstantLoanGetRequest): Promise<InstantLoan> {
     const loanId =
@@ -399,7 +406,12 @@ export class InstantLoansModule {
       borrowAmount: record.borrow_amount,
       borrowDestination: accountFromCanister(record.borrow_destination),
       refundDestination: accountFromCanister(record.refund_destination),
-      started: record.started,
+      deriveStatus: (input) =>
+        deriveInstantLoanRecordStatus({
+          ...input,
+          expiresAt: record.expires_at[0],
+          started: record.started,
+        }),
     });
   }
 
@@ -439,6 +451,7 @@ export class InstantLoansModule {
       borrowAmount: parseBigintWire(loan.borrow.amount, "borrow amount"),
       borrowDestination: accountFromWire(loan.borrow.destination),
       refundDestination: accountFromWire(loan.refundDestination),
+      deriveStatus: deriveInstantLoanWireStatus,
     });
   }
 
@@ -492,62 +505,72 @@ export class InstantLoansModule {
     const currentCollateralAmount = collateralPosition?.deposited ?? 0n;
 
     const collateralAmount = input.collateralAmountHint;
-    const collateralDecimals = collateralPosition?.depositedDecimals ?? 0n;
+    const collateralDecimals =
+      collateralPosition?.depositedDecimals ??
+      getAssetNativeDecimals(collateralAsset);
     const collateralInterestAmount = collateralPosition?.earnedInterest ?? 0n;
 
     const borrowedAmount = borrowPosition?.borrowed ?? 0n;
-    const borrowedDecimals = borrowPosition?.borrowedDecimals ?? 0n;
+    const borrowedDecimals =
+      borrowPosition?.borrowedDecimals ?? getAssetNativeDecimals(borrowAsset);
 
     const debtInterestAmount = borrowPosition?.debtInterest ?? 0n;
 
-    const status = deriveInstantLoanStatus({
+    const status = input.deriveStatus({
       collateralAmount: currentCollateralAmount,
-      started: input.started,
       totalDebtAmount,
     });
 
     const initialDeposit = await this.createInitialDepositQuote({
       collateralAmount,
+      decimals: collateralDecimals,
       asset: collateralAsset,
       target: depositTarget,
     });
+
+    const repayment =
+      totalDebtAmount > 0n
+        ? {
+            amount: repaymentAmount,
+            decimals: borrowedDecimals,
+            debtAmount: totalDebtAmount,
+            interestBufferAmount,
+            interestBufferSeconds: REPAYMENT_BUFFER_SECONDS,
+            inflowFeeAmount: repaymentInflowFee.totalFee,
+            inflowFeeEstimateAvailable: repaymentInflowFee.estimateAvailable,
+            asset: borrowAsset,
+            chain: repayTarget.chain,
+            target: repayTarget,
+          }
+        : null;
 
     return {
       loanId: input.loanId,
       ref: publicIdFromInt(input.loanId),
       status,
       profileId,
-      ltvMaxBps: input.ltvMaxBps,
-      depositWindowSeconds: input.depositWindowSeconds,
+      terms: {
+        ltvMaxBps: input.ltvMaxBps,
+        depositWindowSeconds: input.depositWindowSeconds,
+      },
       collateral: {
         poolId: collateralPoolId,
         asset: collateralAsset,
         chain: depositTarget.chain,
+        decimals: collateralDecimals,
         amount: collateralAmount,
       },
       borrow: {
         poolId: borrowPoolId,
         asset: borrowAsset,
         chain: repayTarget.chain,
+        decimals: borrowedDecimals,
         amount: input.borrowAmount,
         destination: input.borrowDestination,
       },
       refundDestination: input.refundDestination,
-      depositTarget,
-      repayTarget,
       initialDeposit,
-      repayment: {
-        amount: repaymentAmount,
-        decimals: borrowedDecimals,
-        debtAmount: totalDebtAmount,
-        interestBufferAmount,
-        interestBufferSeconds: REPAYMENT_BUFFER_SECONDS,
-        inflowFeeAmount: repaymentInflowFee.totalFee,
-        inflowFeeEstimateAvailable: repaymentInflowFee.estimateAvailable,
-        asset: borrowAsset,
-        chain: repayTarget.chain,
-        target: repayTarget,
-      },
+      repayment,
       position: {
         collateralAmount: currentCollateralAmount,
         collateralDecimals,
@@ -562,6 +585,7 @@ export class InstantLoansModule {
 
   private async createInitialDepositQuote(input: {
     collateralAmount: bigint;
+    decimals: bigint;
     asset: string;
     target: SupplyTarget;
   }): Promise<InstantLoanInitialDeposit> {
@@ -572,6 +596,7 @@ export class InstantLoansModule {
 
     return {
       amount: input.collateralAmount + inflowFee.totalFee,
+      decimals: input.decimals,
       collateralAmount: input.collateralAmount,
       inflowFeeAmount: inflowFee.totalFee,
       asset: input.asset,
@@ -695,6 +720,31 @@ function calculateTotalDebtAmount(borrowPosition: Position | null): bigint {
   return borrowPosition.borrowed + borrowPosition.debtInterest;
 }
 
+function deriveInstantLoanWireStatus(
+  input: InstantLoanStatusHydrationInput
+): InstantLoanStatus {
+  return deriveInstantLoanStatus({ ...input, started: undefined });
+}
+
+function deriveInstantLoanRecordStatus(
+  input: InstantLoanStatusHydrationInput & {
+    expiresAt: bigint | undefined;
+    started: boolean;
+  }
+): InstantLoanStatus {
+  const status = deriveInstantLoanStatus({
+    collateralAmount: input.collateralAmount,
+    started: input.started,
+    totalDebtAmount: input.totalDebtAmount,
+  });
+
+  if (status !== "awaiting_deposit") {
+    return status;
+  }
+
+  return hasExpiredDepositWindow(input.expiresAt) ? "expired" : status;
+}
+
 function deriveInstantLoanStatus(input: {
   collateralAmount: bigint;
   started: boolean | undefined;
@@ -713,6 +763,18 @@ function deriveInstantLoanStatus(input: {
   }
 
   return "awaiting_deposit";
+}
+
+function hasExpiredDepositWindow(expiresAt: bigint | undefined): boolean {
+  if (expiresAt === undefined) {
+    return false;
+  }
+
+  return expiresAt <= currentProtocolTimestamp();
+}
+
+function currentProtocolTimestamp(): bigint {
+  return BigInt(Date.now()) * NANOSECONDS_PER_MILLISECOND;
 }
 
 function validateCreateRequest(request: CreateInstantLoanRequest): void {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -13,7 +13,7 @@ import { mapCanisterCallErrorToLiquidiumError } from "../../core/canisters/lendi
 import { LiquidiumError, LiquidiumErrorCode } from "../../core/errors";
 import {
   buildInstantLoanAddressLookupPath,
-  buildInstantLoanCollateralHintPath,
+  buildInstantLoanCollateralAmountPath,
   SdkApiPath,
 } from "../../core/sdk-api-paths";
 import type { ApiClient } from "../../core/transports/api-client";
@@ -82,8 +82,7 @@ type InstantLoanCandidateWire = {
   lend_asset?: string;
   borrowAsset?: string;
   borrow_asset?: string;
-  collateralAmountHint?: string;
-  min_deposit_hint?: string;
+  collateralAmount: string;
 };
 
 type InstantLoanCreateRequestWire = {
@@ -99,8 +98,8 @@ type InstantLoanCreateRequestWire = {
   refundDestination: InstantLoanCreateAccountWire;
 };
 
-type InstantLoanCollateralHintWire = {
-  collateralAmountHint: string;
+type InstantLoanCollateralAmountWire = {
+  collateralAmount: string;
 };
 
 type InstantLoanCreateAccountWire = { External: string };
@@ -127,7 +126,7 @@ type InstantLoanWire = {
   collateral: {
     poolId: string;
     asset: string;
-    amountHint: string;
+    amount: string;
   };
   borrow: {
     poolId: string;
@@ -144,7 +143,7 @@ type InstantLoanHydrationInput = {
   ltvMaxBps: bigint;
   depositWindowSeconds: bigint;
   collateralPoolId: string;
-  collateralAmountHint: bigint;
+  collateralAmount: bigint;
   borrowPoolId: string;
   collateralAsset: string;
   borrowAsset: string;
@@ -239,9 +238,9 @@ export class InstantLoansModule {
         throw mapInstantLoansErrorToLiquidiumError(result.Err);
       }
 
-      const collateralAmountHint = await this.getCollateralAmountHint(loanId);
+      const collateralAmount = await this.getCollateralAmount(loanId);
 
-      return await this.mapLoanRecord(result.Ok, collateralAmountHint);
+      return await this.mapLoanRecord(result.Ok, collateralAmount);
     } catch (error) {
       if (error instanceof LiquidiumError) {
         throw error;
@@ -391,7 +390,7 @@ export class InstantLoansModule {
 
   private async mapLoanRecord(
     record: InstantLoanCanisterRecord,
-    collateralAmountHint: bigint
+    collateralAmount: bigint
   ): Promise<InstantLoan> {
     return await this.hydrateLoan({
       loanId: record.id,
@@ -399,7 +398,7 @@ export class InstantLoansModule {
       ltvMaxBps: record.ltv_max_bps,
       depositWindowSeconds: record.ltv_timer_s,
       collateralPoolId: record.lend_pool_id.toText(),
-      collateralAmountHint,
+      collateralAmount,
       borrowPoolId: record.borrow_pool_id.toText(),
       collateralAsset: getVariantKey(record.lend_asset),
       borrowAsset: getVariantKey(record.borrow_asset),
@@ -415,18 +414,15 @@ export class InstantLoansModule {
     });
   }
 
-  private async getCollateralAmountHint(loanId: bigint): Promise<bigint> {
+  private async getCollateralAmount(loanId: bigint): Promise<bigint> {
     const apiClient = this.requireApi("Instant loan lookup");
     const response = await apiClient.get<
       {
         success?: true;
-      } & InstantLoanCollateralHintWire
-    >(buildInstantLoanCollateralHintPath({ loanId }));
+      } & InstantLoanCollateralAmountWire
+    >(buildInstantLoanCollateralAmountPath({ loanId }));
 
-    return parseBigintWire(
-      response.collateralAmountHint,
-      "collateral amount hint"
-    );
+    return parseBigintWire(response.collateralAmount, "collateral amount");
   }
 
   private async mapLoanWire(loan: InstantLoanWire): Promise<InstantLoan> {
@@ -441,9 +437,9 @@ export class InstantLoansModule {
         "deposit window"
       ),
       collateralPoolId: loan.collateral.poolId,
-      collateralAmountHint: parseBigintWire(
-        loan.collateral.amountHint,
-        "collateral amount hint"
+      collateralAmount: parseBigintWire(
+        loan.collateral.amount,
+        "collateral amount"
       ),
       borrowPoolId: loan.borrow.poolId,
       collateralAsset: loan.collateral.asset,
@@ -504,7 +500,7 @@ export class InstantLoansModule {
 
     const currentCollateralAmount = collateralPosition?.deposited ?? 0n;
 
-    const collateralAmount = input.collateralAmountHint;
+    const collateralAmount = input.collateralAmount;
     const collateralDecimals =
       collateralPosition?.depositedDecimals ??
       getAssetNativeDecimals(collateralAsset);
@@ -528,21 +524,18 @@ export class InstantLoansModule {
       target: depositTarget,
     });
 
-    const repayment =
-      totalDebtAmount > 0n
-        ? {
-            amount: repaymentAmount,
-            decimals: borrowedDecimals,
-            debtAmount: totalDebtAmount,
-            interestBufferAmount,
-            interestBufferSeconds: REPAYMENT_BUFFER_SECONDS,
-            inflowFeeAmount: repaymentInflowFee.totalFee,
-            inflowFeeEstimateAvailable: repaymentInflowFee.estimateAvailable,
-            asset: borrowAsset,
-            chain: repayTarget.chain,
-            target: repayTarget,
-          }
-        : null;
+    const repayment = {
+      amount: repaymentAmount,
+      decimals: borrowedDecimals,
+      debtAmount: totalDebtAmount,
+      interestBufferAmount,
+      interestBufferSeconds: REPAYMENT_BUFFER_SECONDS,
+      inflowFeeAmount: repaymentInflowFee.totalFee,
+      inflowFeeEstimateAvailable: repaymentInflowFee.estimateAvailable,
+      asset: borrowAsset,
+      chain: repayTarget.chain,
+      target: repayTarget,
+    };
 
     return {
       loanId: input.loanId,
@@ -1021,9 +1014,9 @@ function mapCandidateWire(
       wire.borrowAsset ?? wire.borrow_asset,
       "borrow asset"
     ),
-    collateralAmountHint: parseBigintWire(
-      wire.collateralAmountHint ?? wire.min_deposit_hint,
-      "collateral amount hint"
+    collateralAmount: parseBigintWire(
+      wire.collateralAmount,
+      "collateral amount"
     ),
   };
 }

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -13,7 +13,7 @@ import { mapCanisterCallErrorToLiquidiumError } from "../../core/canisters/lendi
 import { LiquidiumError, LiquidiumErrorCode } from "../../core/errors";
 import {
   buildInstantLoanAddressLookupPath,
-  buildInstantLoanCollateralAmountPath,
+  buildInstantLoanCollateralHintPath,
   SdkApiPath,
 } from "../../core/sdk-api-paths";
 import type { ApiClient } from "../../core/transports/api-client";
@@ -98,8 +98,8 @@ type InstantLoanCreateRequestWire = {
   refundDestination: InstantLoanCreateAccountWire;
 };
 
-type InstantLoanCollateralAmountWire = {
-  collateralAmount: string;
+type InstantLoanCollateralHintWire = {
+  collateralAmountHint: string;
 };
 
 type InstantLoanCreateAccountWire = { External: string };
@@ -121,7 +121,7 @@ type InstantLoanWire = {
   collateral: {
     poolId: string;
     asset: string;
-    amount: string;
+    amountHint: string;
   };
   borrow: {
     poolId: string;
@@ -232,7 +232,7 @@ export class InstantLoansModule {
         throw mapInstantLoansErrorToLiquidiumError(result.Err);
       }
 
-      const collateralAmount = await this.getCollateralAmount(loanId);
+      const collateralAmount = await this.getCollateralAmountHint(loanId);
 
       return await this.mapLoanRecord(result.Ok, collateralAmount);
     } catch (error) {
@@ -402,15 +402,15 @@ export class InstantLoansModule {
     });
   }
 
-  private async getCollateralAmount(loanId: bigint): Promise<bigint> {
+  private async getCollateralAmountHint(loanId: bigint): Promise<bigint> {
     const apiClient = this.requireApi("Instant loan lookup");
     const response = await apiClient.get<
       {
         success?: true;
-      } & InstantLoanCollateralAmountWire
-    >(buildInstantLoanCollateralAmountPath({ loanId }));
+      } & InstantLoanCollateralHintWire
+    >(buildInstantLoanCollateralHintPath({ loanId }));
 
-    return parseBigintWire(response.collateralAmount, "collateral amount");
+    return parseBigintWire(response.collateralAmountHint, "collateral amount");
   }
 
   private async mapLoanWire(loan: InstantLoanWire): Promise<InstantLoan> {
@@ -426,7 +426,7 @@ export class InstantLoansModule {
       ),
       collateralPoolId: loan.collateral.poolId,
       collateralAmount: parseBigintWire(
-        loan.collateral.amount,
+        loan.collateral.amountHint,
         "collateral amount"
       ),
       borrowPoolId: loan.borrow.poolId,

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -48,16 +48,16 @@ import type {
   InstantLoanInitialDeposit,
   InstantLoanLeg,
   InstantLoanListEventsRequest,
-  InstantLoanStatus,
+  InstantLoanStatus as InstantLoanStatusValue,
   InstantLoanWarmedProfile,
 } from "./types";
+import { InstantLoanStatus } from "./types";
 
 const REPAYMENT_BUFFER_SECONDS = 86_400n;
 const RATE_SCALE = 10n ** 27n;
 const SECONDS_PER_YEAR = 31_536_000n;
 const ETH_STABLECOIN_INFLOW_FEE_FALLBACK = 1_500_000n;
 const INSTANT_LOAN_MIN_SLIPPAGE_BUFFER_BPS = 200n;
-const NANOSECONDS_PER_MILLISECOND = 1_000_000n;
 
 type InstantLoanLtvPolicy = {
   ltvBps: bigint;
@@ -112,11 +112,6 @@ type InstantLoanAccountWire =
   | { principal: string; type: "Native" }
   | InstantLoanAccountVariantWire;
 
-type InstantLoanStatusHydrationInput = {
-  collateralAmount: bigint;
-  totalDebtAmount: bigint;
-};
-
 type InstantLoanWire = {
   loanId: string;
   ref?: string;
@@ -150,7 +145,6 @@ type InstantLoanHydrationInput = {
   borrowAmount: bigint;
   borrowDestination: InstantLoanAccount;
   refundDestination: InstantLoanAccount;
-  deriveStatus: (input: InstantLoanStatusHydrationInput) => InstantLoanStatus;
 };
 
 /** Accountless instant-loan creation, lookup, recovery, and canister query helpers. */
@@ -405,12 +399,6 @@ export class InstantLoansModule {
       borrowAmount: record.borrow_amount,
       borrowDestination: accountFromCanister(record.borrow_destination),
       refundDestination: accountFromCanister(record.refund_destination),
-      deriveStatus: (input) =>
-        deriveInstantLoanRecordStatus({
-          ...input,
-          expiresAt: record.expires_at[0],
-          started: record.started,
-        }),
     });
   }
 
@@ -447,7 +435,6 @@ export class InstantLoansModule {
       borrowAmount: parseBigintWire(loan.borrow.amount, "borrow amount"),
       borrowDestination: accountFromWire(loan.borrow.destination),
       refundDestination: accountFromWire(loan.refundDestination),
-      deriveStatus: deriveInstantLoanWireStatus,
     });
   }
 
@@ -512,7 +499,7 @@ export class InstantLoansModule {
 
     const debtInterestAmount = borrowPosition?.debtInterest ?? 0n;
 
-    const status = input.deriveStatus({
+    const status = deriveInstantLoanStatus({
       collateralAmount: currentCollateralAmount,
       totalDebtAmount,
     });
@@ -713,61 +700,19 @@ function calculateTotalDebtAmount(borrowPosition: Position | null): bigint {
   return borrowPosition.borrowed + borrowPosition.debtInterest;
 }
 
-function deriveInstantLoanWireStatus(
-  input: InstantLoanStatusHydrationInput
-): InstantLoanStatus {
-  return deriveInstantLoanStatus({ ...input, started: undefined });
-}
-
-function deriveInstantLoanRecordStatus(
-  input: InstantLoanStatusHydrationInput & {
-    expiresAt: bigint | undefined;
-    started: boolean;
-  }
-): InstantLoanStatus {
-  const status = deriveInstantLoanStatus({
-    collateralAmount: input.collateralAmount,
-    started: input.started,
-    totalDebtAmount: input.totalDebtAmount,
-  });
-
-  if (status !== "awaiting_deposit") {
-    return status;
-  }
-
-  return hasExpiredDepositWindow(input.expiresAt) ? "expired" : status;
-}
-
 function deriveInstantLoanStatus(input: {
   collateralAmount: bigint;
-  started: boolean | undefined;
   totalDebtAmount: bigint;
-}): InstantLoanStatus {
+}): InstantLoanStatusValue {
   if (input.totalDebtAmount > 0n) {
-    return "active";
+    return InstantLoanStatus.active;
   }
 
   if (input.collateralAmount > 0n) {
-    return input.started ? "settling" : "deposit_detected";
+    return InstantLoanStatus.depositDetected;
   }
 
-  if (input.started) {
-    return "closed";
-  }
-
-  return "awaiting_deposit";
-}
-
-function hasExpiredDepositWindow(expiresAt: bigint | undefined): boolean {
-  if (expiresAt === undefined) {
-    return false;
-  }
-
-  return expiresAt <= currentProtocolTimestamp();
-}
-
-function currentProtocolTimestamp(): bigint {
-  return BigInt(Date.now()) * NANOSECONDS_PER_MILLISECOND;
+  return InstantLoanStatus.awaitingDeposit;
 }
 
 function validateCreateRequest(request: CreateInstantLoanRequest): void {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -13,6 +13,7 @@ import { mapCanisterCallErrorToLiquidiumError } from "../../core/canisters/lendi
 import { LiquidiumError, LiquidiumErrorCode } from "../../core/errors";
 import {
   buildInstantLoanAddressLookupPath,
+  buildInstantLoanCollateralHintPath,
   SdkApiPath,
 } from "../../core/sdk-api-paths";
 import type { ApiClient } from "../../core/transports/api-client";
@@ -21,7 +22,7 @@ import { type Asset, type Chain, SupplyAction } from "../../core/types";
 import { getVariantKey } from "../../core/utils/variant";
 import { resolveSupplyTarget } from "../lending/_internal/supply-targets";
 import type { LendingModule } from "../lending/lending";
-import { SupplyPlanType } from "../lending/types";
+import { SupplyPlanType, type SupplyTarget } from "../lending/types";
 import type { PositionsModule } from "../positions";
 import type { Position } from "../positions/types";
 import { QuoteModule } from "../quote";
@@ -43,6 +44,7 @@ import type {
   InstantLoanEvent,
   InstantLoanEventType,
   InstantLoanGetRequest,
+  InstantLoanInitialDeposit,
   InstantLoanLeg,
   InstantLoanListEventsRequest,
   InstantLoanStatus,
@@ -62,8 +64,8 @@ type InstantLoanLtvPolicy = {
 };
 
 type InstantLoanCandidateWire = {
-  loanId?: string | bigint;
-  loan_id?: string | bigint;
+  loanId?: string;
+  loan_id?: string;
   ref?: string;
   short_ref?: string;
   profileId?: string;
@@ -78,8 +80,8 @@ type InstantLoanCandidateWire = {
   lend_asset?: string;
   borrowAsset?: string;
   borrow_asset?: string;
-  collateralAmountHint?: string | bigint;
-  min_deposit_hint?: string | bigint;
+  collateralAmountHint?: string;
+  min_deposit_hint?: string;
 };
 
 type InstantLoanCreateRequestWire = {
@@ -95,6 +97,10 @@ type InstantLoanCreateRequestWire = {
   refundDestination: InstantLoanCreateAccountWire;
 };
 
+type InstantLoanCollateralHintWire = {
+  collateralAmountHint: string;
+};
+
 type InstantLoanCreateAccountWire = { External: string };
 type InstantLoanAccountVariantWire =
   | InstantLoanCreateAccountWire
@@ -106,20 +112,20 @@ type InstantLoanAccountWire =
   | InstantLoanAccountVariantWire;
 
 type InstantLoanWire = {
-  loanId: string | bigint;
+  loanId: string;
   ref?: string;
   profileId: string;
-  ltvMaxBps: string | bigint;
-  depositWindowSeconds: string | bigint;
+  ltvMaxBps: string;
+  depositWindowSeconds: string;
   collateral: {
     poolId: string;
     asset: string;
-    amountHint: string | bigint;
+    amountHint: string;
   };
   borrow: {
     poolId: string;
     asset: string;
-    amount: string | bigint;
+    amount: string;
     destination: InstantLoanAccountWire;
   };
   refundDestination: InstantLoanAccountWire;
@@ -131,6 +137,7 @@ type InstantLoanHydrationInput = {
   ltvMaxBps: bigint;
   depositWindowSeconds: bigint;
   collateralPoolId: string;
+  collateralAmountHint: bigint;
   borrowPoolId: string;
   collateralAsset: string;
   borrowAsset: string;
@@ -164,7 +171,7 @@ export class InstantLoansModule {
    * SDK maps it to the canister's internal `ltv_timer_s` field.
    *
    * @param request - Pool ids, assets, base-unit amounts, LTV limit, timeout, and destinations.
-   * @returns Hydrated loan state plus generated deposit and repayment targets.
+   * @returns Hydrated loan state plus generated targets, initial deposit quote, and repayment quote.
    */
   async create(request: CreateInstantLoanRequest): Promise<InstantLoan> {
     validateCreateRequest(request);
@@ -200,15 +207,7 @@ export class InstantLoansModule {
       refundDestination,
     });
 
-    const loan = await this.mapLoanWire(response.loan);
-
-    return {
-      ...loan,
-      collateral: {
-        ...loan.collateral,
-        amount: request.collateralAmount,
-      },
-    };
+    return await this.mapLoanWire(response.loan);
   }
 
   /**
@@ -233,7 +232,9 @@ export class InstantLoansModule {
         throw mapInstantLoansErrorToLiquidiumError(result.Err);
       }
 
-      return await this.mapLoanRecord(result.Ok);
+      const collateralAmountHint = await this.getCollateralAmountHint(loanId);
+
+      return await this.mapLoanRecord(result.Ok, collateralAmountHint);
     } catch (error) {
       if (error instanceof LiquidiumError) {
         throw error;
@@ -382,7 +383,8 @@ export class InstantLoansModule {
   }
 
   private async mapLoanRecord(
-    record: InstantLoanCanisterRecord
+    record: InstantLoanCanisterRecord,
+    collateralAmountHint: bigint
   ): Promise<InstantLoan> {
     return await this.hydrateLoan({
       loanId: record.id,
@@ -390,6 +392,7 @@ export class InstantLoansModule {
       ltvMaxBps: record.ltv_max_bps,
       depositWindowSeconds: record.ltv_timer_s,
       collateralPoolId: record.lend_pool_id.toText(),
+      collateralAmountHint,
       borrowPoolId: record.borrow_pool_id.toText(),
       collateralAsset: getVariantKey(record.lend_asset),
       borrowAsset: getVariantKey(record.borrow_asset),
@@ -398,6 +401,20 @@ export class InstantLoansModule {
       refundDestination: accountFromCanister(record.refund_destination),
       started: record.started,
     });
+  }
+
+  private async getCollateralAmountHint(loanId: bigint): Promise<bigint> {
+    const apiClient = this.requireApi("Instant loan lookup");
+    const response = await apiClient.get<
+      {
+        success?: true;
+      } & InstantLoanCollateralHintWire
+    >(buildInstantLoanCollateralHintPath({ loanId }));
+
+    return parseBigintWire(
+      response.collateralAmountHint,
+      "collateral amount hint"
+    );
   }
 
   private async mapLoanWire(loan: InstantLoanWire): Promise<InstantLoan> {
@@ -412,6 +429,10 @@ export class InstantLoansModule {
         "deposit window"
       ),
       collateralPoolId: loan.collateral.poolId,
+      collateralAmountHint: parseBigintWire(
+        loan.collateral.amountHint,
+        "collateral amount hint"
+      ),
       borrowPoolId: loan.borrow.poolId,
       collateralAsset: loan.collateral.asset,
       borrowAsset: loan.borrow.asset,
@@ -464,16 +485,22 @@ export class InstantLoansModule {
         : { totalFee: 0n, estimateAvailable: false };
     const repaymentAmount =
       totalDebtAmount + interestBufferAmount + repaymentInflowFee.totalFee;
-    const collateralAmount = collateralPosition?.deposited ?? 0n;
+    const currentCollateralAmount = collateralPosition?.deposited ?? 0n;
+    const collateralAmount = input.collateralAmountHint;
     const collateralDecimals = collateralPosition?.depositedDecimals ?? 0n;
     const collateralInterestAmount = collateralPosition?.earnedInterest ?? 0n;
     const borrowedAmount = borrowPosition?.borrowed ?? 0n;
     const borrowedDecimals = borrowPosition?.borrowedDecimals ?? 0n;
     const debtInterestAmount = borrowPosition?.debtInterest ?? 0n;
     const status = deriveInstantLoanStatus({
-      collateralAmount,
+      collateralAmount: currentCollateralAmount,
       started: input.started,
       totalDebtAmount,
+    });
+    const initialDeposit = await this.createInitialDepositQuote({
+      collateralAmount,
+      asset: collateralAsset,
+      target: depositTarget,
     });
 
     return {
@@ -499,6 +526,7 @@ export class InstantLoansModule {
       refundDestination: input.refundDestination,
       depositTarget,
       repayTarget,
+      initialDeposit,
       repayment: {
         amount: repaymentAmount,
         decimals: borrowedDecimals,
@@ -512,7 +540,7 @@ export class InstantLoansModule {
         target: repayTarget,
       },
       position: {
-        collateralAmount,
+        collateralAmount: currentCollateralAmount,
         collateralDecimals,
         collateralInterestAmount,
         borrowedAmount,
@@ -520,6 +548,26 @@ export class InstantLoansModule {
         debtInterestAmount,
         totalDebtAmount,
       },
+    };
+  }
+
+  private async createInitialDepositQuote(input: {
+    collateralAmount: bigint;
+    asset: string;
+    target: SupplyTarget;
+  }): Promise<InstantLoanInitialDeposit> {
+    const inflowFee = await this.lending.estimateInflowFee({
+      asset: input.asset as Asset,
+      chain: input.target.chain as Chain,
+    });
+
+    return {
+      amount: input.collateralAmount + inflowFee.totalFee,
+      collateralAmount: input.collateralAmount,
+      inflowFeeAmount: inflowFee.totalFee,
+      asset: input.asset,
+      chain: input.target.chain,
+      target: input.target,
     };
   }
 
@@ -909,17 +957,15 @@ function mapCandidateWire(
   };
 }
 
-function parseBigintWire(
-  value: string | bigint | undefined,
-  label: string
-): bigint {
-  if (typeof value === "bigint") return value;
-  if (typeof value === "string" && /^\d+$/.test(value)) return BigInt(value);
+function parseBigintWire(value: string | undefined, label: string): bigint {
+  if (!value || !/^\d+$/.test(value)) {
+    throw new LiquidiumError(
+      LiquidiumErrorCode.VALIDATION_ERROR,
+      `Invalid instant loan ${label}`
+    );
+  }
 
-  throw new LiquidiumError(
-    LiquidiumErrorCode.VALIDATION_ERROR,
-    `Invalid instant loan ${label}`
-  );
+  return BigInt(value);
 }
 
 function requiredString(value: string | undefined, label: string): string {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -474,29 +474,38 @@ export class InstantLoansModule {
       this.positions.getPosition(profileId, borrowPoolId),
       this.positions.market.getPoolRate(borrowPoolId),
     ]);
+
     const totalDebtAmount = calculateTotalDebtAmount(borrowPosition);
     const interestBufferAmount = calculateInterestBufferAmount(
       borrowPosition,
       borrowPoolRate.borrowRate
     );
+
     const repaymentInflowFee =
       totalDebtAmount > 0n
         ? await this.estimateRepaymentInflowFee(borrowAsset, repayTarget.chain)
         : { totalFee: 0n, estimateAvailable: false };
+
     const repaymentAmount =
       totalDebtAmount + interestBufferAmount + repaymentInflowFee.totalFee;
+
     const currentCollateralAmount = collateralPosition?.deposited ?? 0n;
+
     const collateralAmount = input.collateralAmountHint;
     const collateralDecimals = collateralPosition?.depositedDecimals ?? 0n;
     const collateralInterestAmount = collateralPosition?.earnedInterest ?? 0n;
+
     const borrowedAmount = borrowPosition?.borrowed ?? 0n;
     const borrowedDecimals = borrowPosition?.borrowedDecimals ?? 0n;
+
     const debtInterestAmount = borrowPosition?.debtInterest ?? 0n;
+
     const status = deriveInstantLoanStatus({
       collateralAmount: currentCollateralAmount,
       started: input.started,
       totalDebtAmount,
     });
+
     const initialDeposit = await this.createInitialDepositQuote({
       collateralAmount,
       asset: collateralAsset,

--- a/packages/client/src/modules/instant-loans/types.ts
+++ b/packages/client/src/modules/instant-loans/types.ts
@@ -87,7 +87,7 @@ export interface CreateInstantLoanRequest {
    * deposit/inflow fees are deducted. For BTC, pass satoshis. For token assets,
    * convert the UI amount using the selected pool's `decimals` value. After
    * creation, use `loan.initialDeposit.amount` as the fee-inclusive transfer
-   * amount to send to `loan.depositTarget`.
+   * amount to send to `loan.initialDeposit.target`.
    */
   collateralAmount: bigint;
   /**
@@ -252,6 +252,8 @@ export interface InstantLoanRepayment {
 export interface InstantLoanInitialDeposit {
   /** Full amount to send to the deposit target, including the estimated inflow fee. */
   amount: bigint;
+  /** Decimal scale for `amount`, `collateralAmount`, and `inflowFeeAmount`. */
+  decimals: bigint;
   /** Intended credited collateral amount in base units, before inflow fees. */
   collateralAmount: bigint;
   /** Inflow fee amount in base units added to the transfer amount. */
@@ -289,11 +291,50 @@ export const InstantLoanStatus = {
   active: "active",
   settling: "settling",
   closed: "closed",
+  expired: "expired",
 } as const;
 export type InstantLoanStatus =
   (typeof InstantLoanStatus)[keyof typeof InstantLoanStatus];
 
-/** Hydrated instant-loan state plus generated deposit and repayment targets. */
+/** Immutable terms selected for an instant loan. */
+export interface InstantLoanTerms {
+  /** Maximum loan-to-value ratio in basis points. */
+  ltvMaxBps: bigint;
+  /** Seconds allowed for the collateral deposit before timeout. */
+  depositWindowSeconds: bigint;
+}
+
+/** Collateral leg selected for an instant loan. */
+export interface InstantLoanCollateral {
+  /** Principal text of the collateral pool. */
+  poolId: string;
+  /** Collateral asset symbol. */
+  asset: MarketAsset;
+  /** Chain used for collateral deposits. */
+  chain: MarketChain;
+  /** Decimal scale for collateral amounts. */
+  decimals: bigint;
+  /** Intended credited collateral amount in base units, before inflow fees. */
+  amount: bigint;
+}
+
+/** Borrow leg selected for an instant loan. */
+export interface InstantLoanBorrow {
+  /** Principal text of the borrow pool. */
+  poolId: string;
+  /** Borrow asset symbol. */
+  asset: MarketAsset;
+  /** Chain used for repayment. */
+  chain: MarketChain;
+  /** Decimal scale for borrow and debt amounts. */
+  decimals: bigint;
+  /** Requested borrow amount in base units. */
+  amount: bigint;
+  /** Destination that receives the borrowed asset. */
+  destination: InstantLoanAccount;
+}
+
+/** Hydrated instant-loan state plus generated quote targets. */
 export interface InstantLoan {
   /** Canister-assigned loan id. */
   loanId: bigint;
@@ -303,35 +344,18 @@ export interface InstantLoan {
   status: InstantLoanStatus;
   /** Generated lending profile principal used by the instant loan. */
   profileId: string;
-  /** Maximum loan-to-value ratio in basis points. */
-  ltvMaxBps: bigint;
-  /** Seconds allowed for the collateral deposit before timeout. */
-  depositWindowSeconds: bigint;
-  /** Collateral-side pool, asset, chain, and current or requested credited collateral amount. */
-  collateral: {
-    poolId: string;
-    asset: MarketAsset;
-    chain: MarketChain;
-    amount: bigint;
-  };
-  /** Borrow-side pool, asset, chain, requested amount, and destination. */
-  borrow: {
-    poolId: string;
-    asset: MarketAsset;
-    chain: MarketChain;
-    amount: bigint;
-    destination: InstantLoanAccount;
-  };
+  /** Immutable loan terms. */
+  terms: InstantLoanTerms;
+  /** Collateral-side pool, asset, chain, decimals, and requested credited amount. */
+  collateral: InstantLoanCollateral;
+  /** Borrow-side pool, asset, chain, decimals, requested amount, and destination. */
+  borrow: InstantLoanBorrow;
   /** Destination used for collateral refunds or withdrawals. */
   refundDestination: InstantLoanAccount;
-  /** Address or ICRC account where the user deposits collateral. */
-  depositTarget: SupplyTarget;
-  /** Address or ICRC account where the user repays debt. */
-  repayTarget: SupplyTarget;
   /** Current actionable initial collateral deposit quote. */
   initialDeposit: InstantLoanInitialDeposit;
-  /** Current actionable repayment quote. */
-  repayment: InstantLoanRepayment;
+  /** Current actionable repayment quote, or `null` when the loan has no debt. */
+  repayment: InstantLoanRepayment | null;
   /** Current lending position state for the generated profile. */
   position: InstantLoanPositionSummary;
 }

--- a/packages/client/src/modules/instant-loans/types.ts
+++ b/packages/client/src/modules/instant-loans/types.ts
@@ -354,8 +354,8 @@ export interface InstantLoan {
   refundDestination: InstantLoanAccount;
   /** Current actionable initial collateral deposit quote. */
   initialDeposit: InstantLoanInitialDeposit;
-  /** Current actionable repayment quote, or `null` when the loan has no debt. */
-  repayment: InstantLoanRepayment | null;
+  /** Current repayment quote. Amount fields are zero when the loan has no debt. */
+  repayment: InstantLoanRepayment;
   /** Current lending position state for the generated profile. */
   position: InstantLoanPositionSummary;
 }
@@ -383,6 +383,6 @@ export interface InstantLoanCandidate {
   collateralAsset: MarketAsset;
   /** Borrow asset symbol. */
   borrowAsset: MarketAsset;
-  /** Collateral amount hint in base units. */
-  collateralAmountHint: bigint;
+  /** Collateral amount in base units. */
+  collateralAmount: bigint;
 }

--- a/packages/client/src/modules/instant-loans/types.ts
+++ b/packages/client/src/modules/instant-loans/types.ts
@@ -81,11 +81,13 @@ export interface CreateInstantLoanRequest {
    */
   borrowAsset: InstantLoanAsset;
   /**
-   * Amount the user is expected to deposit as collateral, in base units.
+   * Intended credited collateral amount, in base units.
    *
-   * This is used to validate LTV and initialize the loan record. For BTC, pass
-   * satoshis. For token assets, convert the UI amount using the selected pool's
-   * `decimals` value.
+   * This is used to validate LTV and initialize the loan record before
+   * deposit/inflow fees are deducted. For BTC, pass satoshis. For token assets,
+   * convert the UI amount using the selected pool's `decimals` value. After
+   * creation, use `loan.initialDeposit.amount` as the fee-inclusive transfer
+   * amount to send to `loan.depositTarget`.
    */
   collateralAmount: bigint;
   /**
@@ -246,6 +248,22 @@ export interface InstantLoanRepayment {
   target: SupplyTarget;
 }
 
+/** Initial collateral deposit quote returned when an instant loan is created. */
+export interface InstantLoanInitialDeposit {
+  /** Full amount to send to the deposit target, including the estimated inflow fee. */
+  amount: bigint;
+  /** Intended credited collateral amount in base units, before inflow fees. */
+  collateralAmount: bigint;
+  /** Inflow fee amount in base units added to the transfer amount. */
+  inflowFeeAmount: bigint;
+  /** Collateral asset to deposit. */
+  asset: MarketAsset;
+  /** Chain used for the collateral deposit. */
+  chain: MarketChain;
+  /** Address or ICRC account where the collateral should be sent. */
+  target: SupplyTarget;
+}
+
 /** Current lending position backing the instant loan. */
 export interface InstantLoanPositionSummary {
   /** Current collateral amount in the collateral asset's base units. */
@@ -289,7 +307,7 @@ export interface InstantLoan {
   ltvMaxBps: bigint;
   /** Seconds allowed for the collateral deposit before timeout. */
   depositWindowSeconds: bigint;
-  /** Collateral-side pool, asset, chain, and current or requested collateral amount. */
+  /** Collateral-side pool, asset, chain, and current or requested credited collateral amount. */
   collateral: {
     poolId: string;
     asset: MarketAsset;
@@ -310,6 +328,8 @@ export interface InstantLoan {
   depositTarget: SupplyTarget;
   /** Address or ICRC account where the user repays debt. */
   repayTarget: SupplyTarget;
+  /** Current actionable initial collateral deposit quote. */
+  initialDeposit: InstantLoanInitialDeposit;
   /** Current actionable repayment quote. */
   repayment: InstantLoanRepayment;
   /** Current lending position state for the generated profile. */

--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -17,7 +17,7 @@ Priority: authless instant loans are the default product flow. Use `client.insta
 
 When the user asks for a simple borrow, loan, collateral deposit, repayment target, or Liquidium integration and does not explicitly ask to manage Liquidium profiles, implement the authless instant-loan flow with `client.instantLoans`.
 
-Do not require the user to create a Liquidium profile, sign a borrow message, or call `client.lending.borrow(...)` for the default flow. The SDK creates the backing lending profile and returns generated deposit and repayment targets.
+Do not require the user to create a Liquidium profile, sign a borrow message, or call `client.lending.borrow(...)` for the default flow. The SDK creates the backing lending profile and returns generated initial-deposit and repayment quote targets.
 
 Use profile-based `client.accounts` and `client.lending` only when the user explicitly asks for advanced profile management, existing profile positions, manual supply/repay tracking, signed borrow/withdraw flows, or lower-level wallet orchestration.
 
@@ -95,8 +95,8 @@ or route RPC calls through a server if the key must remain private.
 
 Authless instant loans. This is the default simple borrow UX: create a loan,
 show the fee-inclusive initial deposit quote and generated collateral deposit
-address, restore by reference, and show the actionable repayment amount when the
-user wants to close the loan.
+address, restore by reference, and show the actionable repayment amount after
+debt exists.
 
 ```ts
 client.instantLoans.create(...);
@@ -119,19 +119,27 @@ not confuse the quote module's `targetLtvBps` with `create(...)`'s `ltvMaxBps`. 
 from chosen borrow and collateral amounts before calling `create(...)`.
 
 `create(...)` and `get(...)` do not require a wallet adapter, profile ID, or
-message signing. The SDK returns deposit and repay targets for the generated
-`profileId`; `create(...)` and `get(...)` return `initialDeposit.amount` for
-the full amount to send to the deposit target, including the estimated inflow
-fee. `get(...)` also returns `position` plus nullable `repayment` details for
-the full amount to send to the repayment target, including inflow fee and
-interest buffer, when debt exists.
+message signing. The SDK returns quote targets for the generated `profileId`;
+`create(...)` and `get(...)` return `initialDeposit.amount` for the full amount
+to send to the deposit target, including the estimated inflow fee. They also
+return `position` plus a non-null `repayment` quote. Repayment amount fields are
+zero when no debt exists; once debt exists, `repayment.amount` is the full amount
+to send to the repayment target, including inflow fee and interest buffer.
 
 Deposit and repayment targets are distinct generated inflow targets. Show
 `loan.initialDeposit.target` only when asking the user to send collateral. Show
-`loan.repayment.target` only when `loan.repayment` is non-null and the user needs
-to repay debt. Do not assume these addresses/accounts match, do not reuse the
-collateral deposit target for repayment, and do not cache one target for both
-phases.
+`loan.repayment.target` only when `loan.repayment.amount > 0n` and the user
+needs to repay debt. Do not assume these addresses/accounts match, do not reuse
+the collateral deposit target for repayment, and do not cache one target for
+both phases.
+
+Hydrated instant loans use the current public shape: read terms from
+`loan.terms.ltvMaxBps` and `loan.terms.depositWindowSeconds`; read deposit
+instructions from `loan.initialDeposit.amount` and `loan.initialDeposit.target`;
+read repayment instructions from `loan.repayment.amount` and
+`loan.repayment.target`. Do not use removed top-level fields such as
+`loan.depositTarget`, `loan.repayTarget`, `loan.ltvMaxBps`, or
+`loan.depositWindowSeconds`.
 
 Reload with `client.instantLoans.get({ ref })` before displaying repayment
 instructions so the app uses the canonical repayment amount and target.
@@ -362,7 +370,7 @@ Default app sequence:
 2. Optionally call `client.quote.calculateLtv(...)` to show current LTV and the collateral pool's max allowed LTV.
 3. Call `client.instantLoans.create(...)` with direct base-unit amounts and external destination addresses.
 4. Persist or display `loan.ref` as the primary recovery key.
-5. Show `loan.initialDeposit.amount` plus `loan.initialDeposit.target` for collateral deposit and, when `loan.repayment` is non-null, `loan.repayment.target` plus `loan.repayment.amount` for repayment.
+5. Show `loan.initialDeposit.amount` plus `loan.initialDeposit.target` for collateral deposit and, when `loan.repayment.amount > 0n`, `loan.repayment.target` plus `loan.repayment.amount` for repayment.
 
 The default instant-loan flow does not need a wallet adapter. The user signs or
 broadcasts only the external wallet transfer to the generated deposit or repay
@@ -370,7 +378,7 @@ target outside the SDK.
 
 The deposit target and repayment target are not interchangeable. Collateral goes
 to `loan.initialDeposit.target`. Repayment goes to `loan.repayment.target` when
-`loan.repayment` is non-null. If a UI has separate deposit and repay screens,
+`loan.repayment.amount > 0n`. If a UI has separate deposit and repay screens,
 each screen must read the target for that exact phase instead of sharing one
 saved address.
 
@@ -405,7 +413,7 @@ const loan = await client.instantLoans.create({
 const ref = loan.ref;
 const initialDepositAmount = loan.initialDeposit.amount;
 const depositTarget = loan.initialDeposit.target;
-const repayTarget = loan.repayment?.target;
+const repayTarget = loan.repayment.amount > 0n ? loan.repayment.target : null;
 ```
 
 Create destinations are external-only. Pass an external address string or an
@@ -435,12 +443,13 @@ Restore a loan by `ref` whenever possible:
 
 ```ts
 const loan = await client.instantLoans.get({ ref: "8Y9AQQ" });
-const repayAmount = loan.repayment?.amount;
-const repayAddress = loan.repayment
-  ? loan.repayment.target.type === "nativeAddress"
-    ? loan.repayment.target.address
-    : loan.repayment.target.account
-  : undefined;
+const repayAmount = loan.repayment.amount;
+const repayAddress =
+  repayAmount === 0n
+    ? null
+    : loan.repayment.target.type === "nativeAddress"
+      ? loan.repayment.target.address
+      : loan.repayment.target.account;
 ```
 
 Use address lookup only as recovery when the user lost the loan reference:
@@ -709,6 +718,8 @@ const contractInteractionFlow = await client.lending.supply({
 16. Do not trust address lookup as canonical loan state. Use it to find candidates, then hydrate the selected loan through `instantLoans.get(...)`.
 17. Do not confuse deposit/supply targets with repayment targets. They are generated for different inflow actions and may be different addresses/accounts.
 18. Do not render raw `rateDecimals = 27` fixed-point values as percentages. Format scaled rates first or the UI can show scientific notation such as `3.7e+24%`.
+19. Do not model `loan.repayment` as nullable. It is always present; check `loan.repayment.amount > 0n` before prompting repayment.
+20. Do not use removed instant-loan fields: `loan.depositTarget`, `loan.repayTarget`, `loan.ltvMaxBps`, or `loan.depositWindowSeconds`.
 
 ## Preferred Style
 

--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -122,15 +122,16 @@ from chosen borrow and collateral amounts before calling `create(...)`.
 message signing. The SDK returns deposit and repay targets for the generated
 `profileId`; `create(...)` and `get(...)` return `initialDeposit.amount` for
 the full amount to send to the deposit target, including the estimated inflow
-fee. `get(...)` also returns `position` plus `repayment.amount` for the full
-amount to send to the repayment target, including inflow fee and interest
-buffer.
+fee. `get(...)` also returns `position` plus nullable `repayment` details for
+the full amount to send to the repayment target, including inflow fee and
+interest buffer, when debt exists.
 
 Deposit and repayment targets are distinct generated inflow targets. Show
-`loan.depositTarget` only when asking the user to send collateral. Show
-`loan.repayment.target` or `loan.repayTarget` only when asking the user to repay
-debt. Do not assume these addresses/accounts match, do not reuse the collateral
-deposit target for repayment, and do not cache one target for both phases.
+`loan.initialDeposit.target` only when asking the user to send collateral. Show
+`loan.repayment.target` only when `loan.repayment` is non-null and the user needs
+to repay debt. Do not assume these addresses/accounts match, do not reuse the
+collateral deposit target for repayment, and do not cache one target for both
+phases.
 
 Reload with `client.instantLoans.get({ ref })` before displaying repayment
 instructions so the app uses the canonical repayment amount and target.
@@ -361,16 +362,17 @@ Default app sequence:
 2. Optionally call `client.quote.calculateLtv(...)` to show current LTV and the collateral pool's max allowed LTV.
 3. Call `client.instantLoans.create(...)` with direct base-unit amounts and external destination addresses.
 4. Persist or display `loan.ref` as the primary recovery key.
-5. Show `loan.initialDeposit.amount` plus `loan.depositTarget` for collateral deposit and `loan.repayment.target` plus `loan.repayment.amount` for repayment.
+5. Show `loan.initialDeposit.amount` plus `loan.initialDeposit.target` for collateral deposit and, when `loan.repayment` is non-null, `loan.repayment.target` plus `loan.repayment.amount` for repayment.
 
 The default instant-loan flow does not need a wallet adapter. The user signs or
 broadcasts only the external wallet transfer to the generated deposit or repay
 target outside the SDK.
 
 The deposit target and repayment target are not interchangeable. Collateral goes
-to `loan.depositTarget`. Repayment goes to `loan.repayment.target` or
-`loan.repayTarget`. If a UI has separate deposit and repay screens, each screen
-must read the target for that exact phase instead of sharing one saved address.
+to `loan.initialDeposit.target`. Repayment goes to `loan.repayment.target` when
+`loan.repayment` is non-null. If a UI has separate deposit and repay screens,
+each screen must read the target for that exact phase instead of sharing one
+saved address.
 
 ```ts
 const ltv = client.quote.calculateLtv(
@@ -402,8 +404,8 @@ const loan = await client.instantLoans.create({
 
 const ref = loan.ref;
 const initialDepositAmount = loan.initialDeposit.amount;
-const depositTarget = loan.depositTarget;
-const repayTarget = loan.repayTarget;
+const depositTarget = loan.initialDeposit.target;
+const repayTarget = loan.repayment?.target;
 ```
 
 Create destinations are external-only. Pass an external address string or an
@@ -433,11 +435,12 @@ Restore a loan by `ref` whenever possible:
 
 ```ts
 const loan = await client.instantLoans.get({ ref: "8Y9AQQ" });
-const repayAmount = loan.repayment.amount;
-const repayAddress =
-  loan.repayment.target.type === "nativeAddress"
+const repayAmount = loan.repayment?.amount;
+const repayAddress = loan.repayment
+  ? loan.repayment.target.type === "nativeAddress"
     ? loan.repayment.target.address
-    : loan.repayment.target.account;
+    : loan.repayment.target.account
+  : undefined;
 ```
 
 Use address lookup only as recovery when the user lost the loan reference:
@@ -462,11 +465,12 @@ after collateral arrives.
 
 Instant loan status values are UI-facing:
 
-- `awaiting_deposit`: show `loan.depositTarget` and the deposit deadline
+- `awaiting_deposit`: show `loan.initialDeposit.target` and the deposit deadline
 - `deposit_detected`: keep polling and show a pending state
 - `active`: show `loan.repayment.amount` and `loan.repayment.target`
 - `settling`: keep polling and avoid duplicate user actions
 - `closed`: show final state and stop prompting for repayment
+- `expired`: show timeout state and stop prompting for collateral deposit
 
 ### Advanced: create a profile
 

--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -66,7 +66,7 @@ const client = new LiquidiumClient({
 **Config requirements:**
 
 - `environment`: sets the canister preset. Only `mainnet` is bundled; pass `canisterIds` explicitly for custom deployments
-- `apiBaseUrl`: overrides the default Liquidium service root for history, activities, inflow reporting, `instantLoans.create(...)`, and `instantLoans.findByAddress(...)`. It is not needed for `instantLoans.get(...)`, `borrow(...)`, `withdraw(...)`, or default ETH stablecoin deposit-address supply/repay targets
+- `apiBaseUrl`: overrides the default Liquidium service root for history, activities, inflow reporting, `instantLoans.create(...)`, `instantLoans.get(...)`, and `instantLoans.findByAddress(...)`. It is not needed for `borrow(...)`, `withdraw(...)`, or default ETH stablecoin deposit-address supply/repay targets
 - `headers`: adds headers to Liquidium SDK HTTP API requests, for example app attribution or auth from a backend proxy
 - `fetch`: supplies a custom fetch implementation when the runtime needs one
 - `evmRpcUrl` / `evmPublicClient`: required for lower-level ETH contract-interaction supply planning and allowance polling. Use `evmRpcHeaders` when the RPC provider authenticates with HTTP headers
@@ -94,8 +94,9 @@ or route RPC calls through a server if the key must remain private.
 ### instantLoans
 
 Authless instant loans. This is the default simple borrow UX: create a loan,
-show the generated collateral deposit address, restore by reference, and show
-the actionable repayment amount when the user wants to close the loan.
+show the fee-inclusive initial deposit quote and generated collateral deposit
+address, restore by reference, and show the actionable repayment amount when the
+user wants to close the loan.
 
 ```ts
 client.instantLoans.create(...);
@@ -109,7 +110,7 @@ client.quote.calculateLtv(...); // pure helper for current LTV previews
 `depositWindowSeconds` values in base units, plus external borrow/refund
 destinations. It validates positive amounts, loads pools and prices, applies
 SDK-side instant-loan LTV guards, creates the loan, then returns the hydrated
-loan.
+loan with `initialDeposit.amount` for the fee-inclusive collateral transfer.
 
 Current LTV guards require `ltvMaxBps` to be at least the current implied LTV
 plus the SDK slippage buffer and no higher than the collateral pool max LTV. Do
@@ -119,8 +120,10 @@ from chosen borrow and collateral amounts before calling `create(...)`.
 
 `create(...)` and `get(...)` do not require a wallet adapter, profile ID, or
 message signing. The SDK returns deposit and repay targets for the generated
-`profileId`; `get(...)` also returns `position` plus `repayment.amount` for the
-full amount to send to the repayment target, including inflow fee and interest
+`profileId`; `create(...)` and `get(...)` return `initialDeposit.amount` for
+the full amount to send to the deposit target, including the estimated inflow
+fee. `get(...)` also returns `position` plus `repayment.amount` for the full
+amount to send to the repayment target, including inflow fee and interest
 buffer.
 
 Deposit and repayment targets are distinct generated inflow targets. Show
@@ -358,7 +361,7 @@ Default app sequence:
 2. Optionally call `client.quote.calculateLtv(...)` to show current LTV and the collateral pool's max allowed LTV.
 3. Call `client.instantLoans.create(...)` with direct base-unit amounts and external destination addresses.
 4. Persist or display `loan.ref` as the primary recovery key.
-5. Show `loan.depositTarget` for collateral deposit and `loan.repayment.target` plus `loan.repayment.amount` for repayment.
+5. Show `loan.initialDeposit.amount` plus `loan.depositTarget` for collateral deposit and `loan.repayment.target` plus `loan.repayment.amount` for repayment.
 
 The default instant-loan flow does not need a wallet adapter. The user signs or
 broadcasts only the external wallet transfer to the generated deposit or repay
@@ -398,6 +401,7 @@ const loan = await client.instantLoans.create({
 });
 
 const ref = loan.ref;
+const initialDepositAmount = loan.initialDeposit.amount;
 const depositTarget = loan.depositTarget;
 const repayTarget = loan.repayTarget;
 ```
@@ -405,10 +409,12 @@ const repayTarget = loan.repayTarget;
 Create destinations are external-only. Pass an external address string or an
 external account object: `{ type: "External", address: "..." }`.
 
-`collateralAmount` and `borrowAmount` are in each asset's base units. Use pool
-`decimals` and the quote module when building UI inputs. Keep the initial loan
-LTV under the SDK's instant-loan starting-LTV guard and set `ltvMaxBps` within
-the collateral pool's accepted max-LTV range.
+`collateralAmount` and `borrowAmount` are in each asset's base units.
+`collateralAmount` is the intended credited collateral target before
+deposit/inflow fees; use `loan.initialDeposit.amount` as the amount to transfer
+after creation. Use pool `decimals` and the quote module when building UI inputs.
+Keep the initial loan LTV under the SDK's instant-loan starting-LTV guard and set
+`ltvMaxBps` within the collateral pool's accepted max-LTV range.
 
 If the target is a native address, show `target.address`. If it is an ICRC
 account, show `target.account`.
@@ -684,7 +690,7 @@ const contractInteractionFlow = await client.lending.supply({
 1. Treating profile lending as the default borrow flow. Use `client.instantLoans.create(...)` for the authless product flow unless the user explicitly asks for profiles.
 2. Adding profile creation, signed borrow, or wallet adapter requirements to instant loans. `instantLoans.create(...)` and `instantLoans.get(...)` do not need them.
 3. Confusing `quote.targetLtvBps` with instant-loan `ltvMaxBps`. The quote target helps plan amounts; `ltvMaxBps` is validated by the instant-loan LTV guards.
-4. `new LiquidiumClient({})` uses the default Liquidium service configuration. Override `apiBaseUrl` for custom service deployments. Lower-level contract-interaction planning also needs `evmRpcUrl` or `evmPublicClient`. `instantLoans.get(...)`, default ETH stablecoin deposit-address supply, `borrow(...)`, and `withdraw(...)` do not use the service configuration.
+4. `new LiquidiumClient({})` uses the default Liquidium service configuration. Override `apiBaseUrl` for custom service deployments. Lower-level contract-interaction planning also needs `evmRpcUrl` or `evmPublicClient`. Default ETH stablecoin deposit-address supply, `borrow(...)`, and `withdraw(...)` do not use the service configuration.
 5. Prepare methods return signable actions, not completed actions. `prepareCreateProfile`, `prepareBorrow`, and `prepareWithdraw` still need signing and submission.
 6. Build a wallet adapter with only the methods the selected flow needs. Avoid adding `signMessage`, `sendBtcTransaction`, or `sendEthTransaction` unless the flow uses them.
 7. Do not `await client.quote.getQuote(...)`; it is synchronous once pools and prices are available.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instant loans now include an initial-deposit quote (fee-inclusive transfer amount, credited collateral hint, inflow fee); examples/UI show these with market-data-aware formatting. Loan lifecycle includes an expanded set of statuses (adds expired). New exported initial-deposit type exposed.

* **Documentation**
  * READMEs, examples, and SDK guidance updated to use initialDeposit fields, clarify collateralAmount semantics, restore/transfer behavior, and decimals/display guidance.

* **Tests**
  * Tests updated to validate initial-deposit composition, inflow fees, and restored collateral hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->