### PR TITLE
docs: note instant loan activity tracking

### DIFF
--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -132,6 +132,11 @@ deposit target for repayment, and do not cache one target for both phases.
 Reload with `client.instantLoans.get({ ref })` before displaying repayment
 instructions so the app uses the canonical repayment amount and target.
 
+When showing deposit progress, always pair `instantLoans.get({ ref })` with
+`activities.list({ shortRef: ref, filter: "active" })`. The canonical loan
+status may still be `awaiting_deposit` while the activity stream already shows
+detected or processing confirmations.
+
 `findByAddress(...)` is a recovery helper and returns candidates only. Follow it
 with `get({ loanId })` or `get({ ref })` before showing canonical loan state.
 


### PR DESCRIPTION
## Summary
- add guidance to pair instant loan reloads with active activity polling when showing deposit progress

## Verification
- verified `activities.list({ shortRef, filter: "active" })` is supported by SDK types, README examples, and tests
- verified loan status is derived separately from canister loan fields while activities come from the SDK API after resolving the short ref to the generated profile
- ran `python3 /home/robin/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/liquidium-sdk-integration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on implementing accurate deposit progress displays for instant loans, recommending API query patterns to synchronize status with activity confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->