### PR TITLE
fix(client): round up inflow fee estimates

### DIFF
--- a/docs/api-reference/generated/classes/LendingModule.md
+++ b/docs/api-reference/generated/classes/LendingModule.md
@@ -6,7 +6,7 @@
 
 # Class: LendingModule
 
-Defined in: [packages/client/src/modules/lending/lending.ts:120](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L120)
+Defined in: [packages/client/src/modules/lending/lending.ts:121](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L121)
 
 Borrow, withdraw, supply, inflow reporting, and fee-estimation helpers.
 
@@ -16,7 +16,7 @@ Borrow, withdraw, supply, inflow reporting, and fee-estimation helpers.
 
 > **new LendingModule**(`canisterContext`, `apiClient`, `evmReadClient`): `LendingModule`
 
-Defined in: [packages/client/src/modules/lending/lending.ts:121](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L121)
+Defined in: [packages/client/src/modules/lending/lending.ts:122](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L122)
 
 #### Parameters
 
@@ -42,7 +42,7 @@ Defined in: [packages/client/src/modules/lending/lending.ts:121](https://github.
 
 > **borrow**(`params`): `Promise`\<[`BorrowOutflowDetails`](../type-aliases/BorrowOutflowDetails.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:390](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L390)
+Defined in: [packages/client/src/modules/lending/lending.ts:391](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L391)
 
 Creates a borrow outflow using the provided wallet adapter.
 
@@ -73,7 +73,7 @@ poll for it. Use history or app-level polling if you need the chain transaction 
 
 > **estimateInflowFee**(`request`): `Promise`\<[`InflowFeeEstimate`](../interfaces/InflowFeeEstimate.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:614](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L614)
+Defined in: [packages/client/src/modules/lending/lending.ts:615](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L615)
 
 Estimates the network/deposit fee for an inflow target.
 
@@ -92,7 +92,7 @@ Asset and chain pair to estimate for.
 
 `Promise`\<[`InflowFeeEstimate`](../interfaces/InflowFeeEstimate.md)\>
 
-Total fee estimate in the asset's base units.
+Total fee estimate rounded up in the asset's base units.
 
 ***
 
@@ -100,7 +100,7 @@ Total fee estimate in the asset's base units.
 
 > **getDepositAddress**(`request`): `Promise`\<`string`\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:569](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L569)
+Defined in: [packages/client/src/modules/lending/lending.ts:570](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L570)
 
 Returns the read-only deposit address for an ETH stablecoin inflow target.
 
@@ -141,7 +141,7 @@ The EVM deposit address for the derived account.
 
 > **getEvmSupplyContext**(`request`): `Promise`\<[`EvmSupplyContext`](../interfaces/EvmSupplyContext.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:481](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L481)
+Defined in: [packages/client/src/modules/lending/lending.ts:482](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L482)
 
 Fetches ERC-20 supply planning data with the configured EVM read client.
 
@@ -168,7 +168,7 @@ Locally computed [EvmSupplyContext](../interfaces/EvmSupplyContext.md) for appro
 
 > **isBorrowingDisabled**(): `Promise`\<`boolean`\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:968](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L968)
+Defined in: [packages/client/src/modules/lending/lending.ts:974](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L974)
 
 Returns whether borrowing is currently disabled by the protocol.
 
@@ -184,7 +184,7 @@ Returns whether borrowing is currently disabled by the protocol.
 
 > **prepareBorrow**(`request`): `Promise`\<[`BorrowAction`](../interfaces/BorrowAction.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:272](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L272)
+Defined in: [packages/client/src/modules/lending/lending.ts:273](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L273)
 
 Prepares a borrow action that can be signed and submitted later.
 
@@ -210,7 +210,7 @@ A signable [BorrowAction](../interfaces/BorrowAction.md) with `submit` wired to 
 
 > **prepareWithdraw**(`request`): `Promise`\<[`WithdrawAction`](../interfaces/WithdrawAction.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:135](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L135)
+Defined in: [packages/client/src/modules/lending/lending.ts:136](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L136)
 
 Prepares a withdraw action that can be signed and submitted later.
 
@@ -236,7 +236,7 @@ A signable [WithdrawAction](../interfaces/WithdrawAction.md) with `submit` wired
 
 > **submitInflow**(`request`): `Promise`\<[`SubmitInflowResponse`](../interfaces/SubmitInflowResponse.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:952](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L952)
+Defined in: [packages/client/src/modules/lending/lending.ts:958](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L958)
 
 Submits an inflow transaction id for faster indexing.
 
@@ -262,7 +262,7 @@ Acknowledgement including the submitted `txid`.
 
 > **supply**(`request`): `Promise`\<[`SupplyFlow`](../interfaces/SupplyFlow.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:415](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L415)
+Defined in: [packages/client/src/modules/lending/lending.ts:416](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L416)
 
 Resolves a supply target for a deposit or repayment and optionally broadcasts it.
 
@@ -292,7 +292,7 @@ A [SupplyFlow](../interfaces/SupplyFlow.md) receipt with `type`, `target`, `subm
 
 > **withdraw**(`params`): `Promise`\<[`WithdrawOutflowDetails`](../type-aliases/WithdrawOutflowDetails.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:252](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L252)
+Defined in: [packages/client/src/modules/lending/lending.ts:253](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L253)
 
 Creates a withdraw outflow using the provided wallet adapter.
 

--- a/docs/api-reference/generated/interfaces/InflowFeeEstimate.md
+++ b/docs/api-reference/generated/interfaces/InflowFeeEstimate.md
@@ -8,7 +8,7 @@
 
 Defined in: [packages/client/src/modules/lending/types.ts:288](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/types.ts#L288)
 
-Fee estimate for an inflow target.
+Fee estimate for an inflow target, rounded up to the asset's fee unit.
 
 ## Properties
 
@@ -18,4 +18,4 @@ Fee estimate for an inflow target.
 
 Defined in: [packages/client/src/modules/lending/types.ts:290](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/types.ts#L290)
 
-Estimated total fee in the asset's base units.
+Estimated total fee rounded up in the asset's base units.

--- a/docs/api-reference/generated/type-aliases/WalletExecutionParams.md
+++ b/docs/api-reference/generated/type-aliases/WalletExecutionParams.md
@@ -8,7 +8,7 @@
 
 > **WalletExecutionParams** = `object`
 
-Defined in: [packages/client/src/modules/lending/lending.ts:97](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L97)
+Defined in: [packages/client/src/modules/lending/lending.ts:98](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L98)
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [packages/client/src/modules/lending/lending.ts:97](https://github.c
 
 > **signerChain**: [`Chain`](Chain.md)
 
-Defined in: [packages/client/src/modules/lending/lending.ts:98](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L98)
+Defined in: [packages/client/src/modules/lending/lending.ts:99](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L99)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/modules/lending/lending.ts:98](https://github.c
 
 > **signerWalletAdapter**: [`WalletAdapter`](../interfaces/WalletAdapter.md)
 
-Defined in: [packages/client/src/modules/lending/lending.ts:99](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L99)
+Defined in: [packages/client/src/modules/lending/lending.ts:100](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L100)

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -2815,9 +2815,13 @@ describe("LendingModule", () => {
     expect(result.approvalStrategy).toBe("reset-then-approve-max");
   });
 
-  test("estimates eth usdt inflow fee from the deposit canister", async () => {
+  test("estimates eth usdt inflow fee by rounding up", async () => {
     // given
-    const estimateDepositFee = vi.fn().mockResolvedValue({ Ok: 12_345n });
+    const ETH_DEPOSIT_FEE_ESTIMATE = 1_198_098n;
+    const EXPECTED_ROUNDED_FEE = 1_200_000n;
+    const estimateDepositFee = vi.fn().mockResolvedValue({
+      Ok: ETH_DEPOSIT_FEE_ESTIMATE,
+    });
     vi.spyOn(Actor, "createActor").mockReturnValue({
       estimate_deposit_fee: estimateDepositFee,
     } as never);
@@ -2830,10 +2834,58 @@ describe("LendingModule", () => {
     });
 
     // then
-    expect(estimate.totalFee).toBe(12_345n);
+    expect(estimate.totalFee).toBe(EXPECTED_ROUNDED_FEE);
     expect(estimateDepositFee).toHaveBeenCalledWith([
       "0xdac17f958d2ee523a2206206994597c13d831ec7",
     ]);
+  });
+
+  test("rounds a four-cent eth usdt inflow fee up to ten cents", async () => {
+    // given
+    const FOUR_CENT_FEE_ESTIMATE = 40_000n;
+    const EXPECTED_TEN_CENT_FEE = 100_000n;
+    const estimateDepositFee = vi.fn().mockResolvedValue({
+      Ok: FOUR_CENT_FEE_ESTIMATE,
+    });
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      estimate_deposit_fee: estimateDepositFee,
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const estimate = await client.lending.estimateInflowFee({
+      asset: "USDT",
+      chain: "ETH",
+    });
+
+    // then
+    expect(estimate.totalFee).toBe(EXPECTED_TEN_CENT_FEE);
+  });
+
+  test("estimates btc inflow fee by rounding up to sat-level unit", async () => {
+    // given
+    const BTC_MINTER_DEPOSIT_FEE_SATS = 2_000n;
+    const CKBTC_LEDGER_FEE_SATS = 10n;
+    const EXPECTED_ROUNDED_FEE_SATS = 2_500n;
+    const getDepositFee = vi
+      .fn()
+      .mockResolvedValue(BTC_MINTER_DEPOSIT_FEE_SATS);
+    const icrc1Fee = vi.fn().mockResolvedValue(CKBTC_LEDGER_FEE_SATS);
+    vi.spyOn(Actor, "createActor")
+      .mockReturnValueOnce({ get_deposit_fee: getDepositFee } as never)
+      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const estimate = await client.lending.estimateInflowFee({
+      asset: "BTC",
+      chain: "BTC",
+    });
+
+    // then
+    expect(estimate.totalFee).toBe(EXPECTED_ROUNDED_FEE_SATS);
+    expect(getDepositFee).toHaveBeenCalledWith();
+    expect(icrc1Fee).toHaveBeenCalledWith();
   });
 
   test("auto-executes eth usdt supply with a deposit address transfer", async () => {
@@ -4202,10 +4254,10 @@ describe("InstantLoansModule", () => {
     expect(loan).not.toHaveProperty("depositTarget");
     expect(loan).not.toHaveProperty("repayTarget");
     expect(loan.initialDeposit).toMatchObject({
-      amount: 10_002_010n,
+      amount: 10_002_500n,
       decimals: 8n,
       collateralAmount: 10_000_000n,
-      inflowFeeAmount: 2_010n,
+      inflowFeeAmount: 2_500n,
       asset: "BTC",
       chain: "BTC",
       target: expect.objectContaining({
@@ -4311,11 +4363,11 @@ describe("InstantLoansModule", () => {
 
     // then
     expect(loan.repayment).toMatchObject({
-      amount: 1_002_537n,
+      amount: 1_003_027n,
       decimals: 8n,
       debtAmount: 1_000_500n,
       interestBufferAmount: 27n,
-      inflowFeeAmount: 2_010n,
+      inflowFeeAmount: 2_500n,
       inflowFeeEstimateAvailable: true,
       asset: "BTC",
       chain: "BTC",
@@ -4473,7 +4525,7 @@ describe("InstantLoansModule", () => {
       asset: "USDT",
       chain: "ETH",
     });
-    expect(loan.initialDeposit.amount).toBe(10_002_010n);
+    expect(loan.initialDeposit.amount).toBe(10_002_500n);
     expect(loan.status).toBe("awaiting_deposit");
     expect(estimateDepositFee).not.toHaveBeenCalled();
   });
@@ -4641,8 +4693,7 @@ describe("InstantLoansModule", () => {
     });
 
     // then
-    const EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS =
-      10_000_000n + BTC_MINTER_DEPOSIT_FEE_SATS + CKBTC_LEDGER_FEE_SATS;
+    const EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS = 10_000_000n + 2_500n;
 
     expect(fetchSpy).toHaveBeenCalledWith(
       `${DEFAULT_API_BASE_URL}/v1/instant-loans`,
@@ -4688,7 +4739,7 @@ describe("InstantLoansModule", () => {
       amount: EXPECTED_INITIAL_DEPOSIT_AMOUNT_SATS,
       decimals: 8n,
       collateralAmount: 10_000_000n,
-      inflowFeeAmount: BTC_MINTER_DEPOSIT_FEE_SATS + CKBTC_LEDGER_FEE_SATS,
+      inflowFeeAmount: 2_500n,
       asset: "BTC",
       chain: "BTC",
       target: expect.objectContaining({

--- a/packages/client/src/modules/lending/_internal/inflow-fee-rounding.test.ts
+++ b/packages/client/src/modules/lending/_internal/inflow-fee-rounding.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+import { Asset, Chain } from "../../../core/types";
+import { roundInflowFeeEstimate } from "./inflow-fee-rounding";
+
+describe("roundInflowFeeEstimate", () => {
+  test("should round eth usdt inflow fees up to the nearest ten cents", () => {
+    // given
+    const ETH_USDT_FEE_ESTIMATE = 1_198_098n;
+    const EXPECTED_ROUNDED_FEE = 1_200_000n;
+
+    // when
+    const result = roundInflowFeeEstimate(
+      { asset: Asset.USDT, chain: Chain.ETH },
+      ETH_USDT_FEE_ESTIMATE
+    );
+
+    // then
+    expect(result).toBe(EXPECTED_ROUNDED_FEE);
+  });
+
+  test("should round eth usdc inflow fees below ten cents up to ten cents", () => {
+    // given
+    const ETH_USDC_FEE_ESTIMATE = 40_000n;
+    const EXPECTED_ROUNDED_FEE = 100_000n;
+
+    // when
+    const result = roundInflowFeeEstimate(
+      { asset: Asset.USDC, chain: Chain.ETH },
+      ETH_USDC_FEE_ESTIMATE
+    );
+
+    // then
+    expect(result).toBe(EXPECTED_ROUNDED_FEE);
+  });
+
+  test("should leave eth stablecoin inflow fees already on a ten-cent boundary unchanged", () => {
+    // given
+    const ETH_STABLECOIN_FEE_ESTIMATE = 1_200_000n;
+
+    // when
+    const result = roundInflowFeeEstimate(
+      { asset: Asset.USDT, chain: Chain.ETH },
+      ETH_STABLECOIN_FEE_ESTIMATE
+    );
+
+    // then
+    expect(result).toBe(ETH_STABLECOIN_FEE_ESTIMATE);
+  });
+
+  test("should round btc inflow fees up to the nearest five hundred sats", () => {
+    // given
+    const BTC_FEE_ESTIMATE_SATS = 2_010n;
+    const EXPECTED_ROUNDED_FEE_SATS = 2_500n;
+
+    // when
+    const result = roundInflowFeeEstimate(
+      { asset: Asset.BTC, chain: Chain.BTC },
+      BTC_FEE_ESTIMATE_SATS
+    );
+
+    // then
+    expect(result).toBe(EXPECTED_ROUNDED_FEE_SATS);
+  });
+
+  test("should leave btc inflow fees already on a five-hundred-sat boundary unchanged", () => {
+    // given
+    const BTC_FEE_ESTIMATE_SATS = 2_500n;
+
+    // when
+    const result = roundInflowFeeEstimate(
+      { asset: Asset.BTC, chain: Chain.BTC },
+      BTC_FEE_ESTIMATE_SATS
+    );
+
+    // then
+    expect(result).toBe(BTC_FEE_ESTIMATE_SATS);
+  });
+
+  test("should return zero for zero or negative inflow fee estimates", () => {
+    // given
+    const ZERO_FEE_ESTIMATE = 0n;
+    const NEGATIVE_FEE_ESTIMATE = -1n;
+    const EXPECTED_FEE = 0n;
+
+    // when
+    const zeroResult = roundInflowFeeEstimate(
+      { asset: Asset.USDT, chain: Chain.ETH },
+      ZERO_FEE_ESTIMATE
+    );
+    const negativeResult = roundInflowFeeEstimate(
+      { asset: Asset.BTC, chain: Chain.BTC },
+      NEGATIVE_FEE_ESTIMATE
+    );
+
+    // then
+    expect(zeroResult).toBe(EXPECTED_FEE);
+    expect(negativeResult).toBe(EXPECTED_FEE);
+  });
+
+  test("should return unsupported asset pairs unchanged", () => {
+    // given
+    const SOL_FEE_ESTIMATE = 123_456n;
+
+    // when
+    const result = roundInflowFeeEstimate(
+      { asset: Asset.SOL, chain: Chain.ETH },
+      SOL_FEE_ESTIMATE
+    );
+
+    // then
+    expect(result).toBe(SOL_FEE_ESTIMATE);
+  });
+});

--- a/packages/client/src/modules/lending/_internal/inflow-fee-rounding.ts
+++ b/packages/client/src/modules/lending/_internal/inflow-fee-rounding.ts
@@ -1,0 +1,40 @@
+import { Asset, Chain } from "../../../core/types";
+import { ceilDivBigint } from "../../../core/utils/bigint";
+import type { EstimateInflowFeeRequest } from "../types";
+import { isEthStablecoin } from "./supply-targets";
+
+const ETH_STABLECOIN_INFLOW_FEE_ROUND_UP_TO_NEAREST_10_CENTS = 100_000n;
+const BTC_INFLOW_FEE_ROUND_UP_TO_NEAREST_SATS = 500n;
+
+/**
+ * Rounds an inflow fee estimate up to the configured unit for its asset.
+ *
+ * ETH stablecoin fees use 6 decimals, so 100_000 base units is $0.10.
+ * BTC fees use sats, so the fee is rounded up to the nearest 500 sats.
+ */
+export function roundInflowFeeEstimate(
+  request: EstimateInflowFeeRequest,
+  totalFee: bigint
+): bigint {
+  if (totalFee <= 0n) {
+    return 0n;
+  }
+
+  if (isEthStablecoin(request.asset, request.chain)) {
+    return roundUpToNearest(
+      totalFee,
+      ETH_STABLECOIN_INFLOW_FEE_ROUND_UP_TO_NEAREST_10_CENTS
+    );
+  }
+
+  if (request.asset === Asset.BTC && request.chain === Chain.BTC) {
+    return roundUpToNearest(totalFee, BTC_INFLOW_FEE_ROUND_UP_TO_NEAREST_SATS);
+  }
+
+  return totalFee;
+}
+
+/** Rounds a positive bigint up to the nearest multiple of the rounding unit. */
+function roundUpToNearest(amount: bigint, roundingUnit: bigint): bigint {
+  return ceilDivBigint(amount, roundingUnit) * roundingUnit;
+}

--- a/packages/client/src/modules/lending/lending.ts
+++ b/packages/client/src/modules/lending/lending.ts
@@ -49,6 +49,7 @@ import {
   WalletExecutionKind,
 } from "../../core/wallet-actions";
 import { executeWith } from "../../execute";
+import { roundInflowFeeEstimate } from "./_internal/inflow-fee-rounding";
 import {
   getEthStablecoinContractAddress,
   isEthStablecoin,
@@ -609,7 +610,7 @@ export class LendingModule {
    * canister. BTC estimates include the ckBTC minter deposit fee and ledger fee.
    *
    * @param request - Asset and chain pair to estimate for.
-   * @returns Total fee estimate in the asset's base units.
+   * @returns Total fee estimate rounded up in the asset's base units.
    */
   async estimateInflowFee(
     request: EstimateInflowFeeRequest
@@ -623,11 +624,16 @@ export class LendingModule {
         throw mapDepositAccountErrorToLiquidiumError(result.Err);
       }
 
-      return { totalFee: result.Ok };
+      return {
+        totalFee: roundInflowFeeEstimate(request, result.Ok),
+      };
     }
 
     if (request.asset === Asset.BTC && request.chain === Chain.BTC) {
-      return await this.estimateBtcInflowFee();
+      const estimate = await this.estimateBtcInflowFee();
+      return {
+        totalFee: roundInflowFeeEstimate(request, estimate.totalFee),
+      };
     }
 
     throw new LiquidiumError(

--- a/packages/client/src/modules/lending/types.ts
+++ b/packages/client/src/modules/lending/types.ts
@@ -284,9 +284,9 @@ export interface EstimateInflowFeeRequest {
   chain: Chain;
 }
 
-/** Fee estimate for an inflow target. */
+/** Fee estimate for an inflow target, rounded up to the asset's fee unit. */
 export interface InflowFeeEstimate {
-  /** Estimated total fee in the asset's base units. */
+  /** Estimated total fee rounded up in the asset's base units. */
   totalFee: bigint;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced rounded inflow-fee estimates: ETH stablecoins round up to a 10-cent equivalent; BTC rounds up to 500 sats.

* **Bug Fixes**
  * Fee results now consistently return rounded-up values for applicable assets.

* **Documentation**
  * Updated API docs to state that inflow fee estimates are returned rounded in asset base units.

* **Tests**
  * Added coverage for rounding rules and edge cases (zero/negative/unsupported).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liquidium-Inc/liquidium-sdk/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->