### PR TITLE
feat(client): expose initial deposit timestamps

### DIFF
--- a/.changeset/initial-deposit-timestamps.md
+++ b/.changeset/initial-deposit-timestamps.md
@@ -1,0 +1,5 @@
+---
+"@liquidium/client": minor
+---
+
+Expose instant loan initial deposit detection and expiry timestamps.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Most instant-loan UIs show or store these fields:
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
 | `loan.initialDeposit.detectedTimestamp` | Unix timestamp in seconds when the collateral deposit was detected, or `null` before detection |
-| `loan.initialDeposit.expiryTimestamp` | Unix timestamp in seconds when the collateral deposit window expires, or `null` when unavailable |
+| `loan.initialDeposit.expiryTimestamp` | Unix timestamp in seconds when the collateral deposit window expires, or `null` before detection when unavailable |
 | `loan.repayment?.amount` | Full amount to repay, including fee and interest buffer, when debt exists |
 | `loan.repayment?.target` | Address or ICRC account where the user sends repayment, when debt exists |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Most instant-loan UIs show or store these fields:
 | `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
+| `loan.initialDeposit.detectedTimestamp` | Unix timestamp in seconds when the collateral deposit was detected, or `null` before detection |
+| `loan.initialDeposit.expiryTimestamp` | Unix timestamp in seconds when the collateral deposit window expires, or `null` when unavailable |
 | `loan.repayment?.amount` | Full amount to repay, including fee and interest buffer, when debt exists |
 | `loan.repayment?.target` | Address or ICRC account where the user sends repayment, when debt exists |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |

--- a/docs/api-reference/generated/classes/InstantLoansModule.md
+++ b/docs/api-reference/generated/classes/InstantLoansModule.md
@@ -6,7 +6,7 @@
 
 # Class: InstantLoansModule
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:218](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L218)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:173](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L173)
 
 Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
@@ -16,7 +16,7 @@ Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
 > **new InstantLoansModule**(`canisterContext`, `apiClient`, `lending`, `positions`): `InstantLoansModule`
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:219](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L219)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:174](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L174)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:219](htt
 
 > **countWarmedProfiles**(): `Promise`\<`bigint`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:393](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L393)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:340](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L340)
 
 Returns the current size of the warmed-profile pool via direct query.
 
@@ -62,7 +62,7 @@ Number of warmed profiles available on the canister.
 
 > **create**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:243](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L243)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:198](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L198)
 
 Creates a profileless instant loan and returns canonical canister state plus
 generated initial-deposit and repayment quote targets.
@@ -97,7 +97,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **findByAddress**(`address`): `Promise`\<[`InstantLoanCandidate`](../interfaces/InstantLoanCandidate.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:433](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L433)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:380](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L380)
 
 Finds candidate loans associated with an address through the Liquidium SDK
 API. Returns discovery candidates only; call `get(...)` to hydrate canister state.
@@ -125,7 +125,7 @@ Lightweight loan candidates associated with the address.
 
 > **get**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:289](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L289)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:251](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L251)
 
 Resolves canonical canister state by loan id or short reference.
 
@@ -152,7 +152,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **getConfig**(): `Promise`\<[`InstantLoanConfig`](../interfaces/InstantLoanConfig.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:319](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L319)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:266](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L266)
 
 Returns the active instant-loans canister config via direct query.
 
@@ -168,7 +168,7 @@ Active canister configuration.
 
 > **getEvent**(`eventId`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md) \| `null`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:339](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L339)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:286](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L286)
 
 Returns a single canister event by id via direct query.
 
@@ -192,7 +192,7 @@ The event when found, otherwise `null`.
 
 > **listAccessList**(): `Promise`\<`string`[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:376](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L376)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:323](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L323)
 
 Returns principals authorized for protected update callbacks.
 
@@ -208,7 +208,7 @@ Principal text values on the canister access list.
 
 > **listEvents**(`request`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:357](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L357)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:304](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L304)
 
 Returns a page of canister events via direct query.
 
@@ -232,7 +232,7 @@ Canister events in ascending id order.
 
 > **listWarmedProfiles**(): `Promise`\<[`InstantLoanWarmedProfile`](../interfaces/InstantLoanWarmedProfile.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:411](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L411)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:358](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L358)
 
 Returns warmed profiles currently available for future instant loans.
 

--- a/docs/api-reference/generated/classes/InstantLoansModule.md
+++ b/docs/api-reference/generated/classes/InstantLoansModule.md
@@ -6,7 +6,7 @@
 
 # Class: InstantLoansModule
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:207](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L207)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:216](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L216)
 
 Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
@@ -16,7 +16,7 @@ Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
 > **new InstantLoansModule**(`canisterContext`, `apiClient`, `lending`, `positions`): `InstantLoansModule`
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:208](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L208)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:217](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L217)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:208](htt
 
 > **countWarmedProfiles**(): `Promise`\<`bigint`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:382](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L382)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:391](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L391)
 
 Returns the current size of the warmed-profile pool via direct query.
 
@@ -62,7 +62,7 @@ Number of warmed profiles available on the canister.
 
 > **create**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:232](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L232)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:241](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L241)
 
 Creates a profileless instant loan and returns canonical canister state plus
 generated initial-deposit and repayment quote targets.
@@ -97,7 +97,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **findByAddress**(`address`): `Promise`\<[`InstantLoanCandidate`](../interfaces/InstantLoanCandidate.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:422](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L422)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:431](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L431)
 
 Finds candidate loans associated with an address through the Liquidium SDK
 API. Returns discovery candidates only; call `get(...)` to hydrate canister state.
@@ -125,7 +125,7 @@ Lightweight loan candidates associated with the address.
 
 > **get**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:278](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L278)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:287](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L287)
 
 Resolves canonical canister state by loan id or short reference.
 
@@ -152,7 +152,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **getConfig**(): `Promise`\<[`InstantLoanConfig`](../interfaces/InstantLoanConfig.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:308](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L308)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:317](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L317)
 
 Returns the active instant-loans canister config via direct query.
 
@@ -168,7 +168,7 @@ Active canister configuration.
 
 > **getEvent**(`eventId`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md) \| `null`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:328](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L328)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:337](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L337)
 
 Returns a single canister event by id via direct query.
 
@@ -192,7 +192,7 @@ The event when found, otherwise `null`.
 
 > **listAccessList**(): `Promise`\<`string`[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:365](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L365)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:374](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L374)
 
 Returns principals authorized for protected update callbacks.
 
@@ -208,7 +208,7 @@ Principal text values on the canister access list.
 
 > **listEvents**(`request`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:346](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L346)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:355](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L355)
 
 Returns a page of canister events via direct query.
 
@@ -232,7 +232,7 @@ Canister events in ascending id order.
 
 > **listWarmedProfiles**(): `Promise`\<[`InstantLoanWarmedProfile`](../interfaces/InstantLoanWarmedProfile.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:400](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L400)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:409](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L409)
 
 Returns warmed profiles currently available for future instant loans.
 

--- a/docs/api-reference/generated/classes/InstantLoansModule.md
+++ b/docs/api-reference/generated/classes/InstantLoansModule.md
@@ -6,7 +6,7 @@
 
 # Class: InstantLoansModule
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:216](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L216)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:218](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L218)
 
 Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
@@ -16,7 +16,7 @@ Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
 > **new InstantLoansModule**(`canisterContext`, `apiClient`, `lending`, `positions`): `InstantLoansModule`
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:217](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L217)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:219](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L219)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:217](htt
 
 > **countWarmedProfiles**(): `Promise`\<`bigint`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:391](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L391)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:393](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L393)
 
 Returns the current size of the warmed-profile pool via direct query.
 
@@ -62,7 +62,7 @@ Number of warmed profiles available on the canister.
 
 > **create**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:241](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L241)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:243](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L243)
 
 Creates a profileless instant loan and returns canonical canister state plus
 generated initial-deposit and repayment quote targets.
@@ -97,7 +97,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **findByAddress**(`address`): `Promise`\<[`InstantLoanCandidate`](../interfaces/InstantLoanCandidate.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:431](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L431)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:433](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L433)
 
 Finds candidate loans associated with an address through the Liquidium SDK
 API. Returns discovery candidates only; call `get(...)` to hydrate canister state.
@@ -125,7 +125,7 @@ Lightweight loan candidates associated with the address.
 
 > **get**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:287](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L287)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:289](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L289)
 
 Resolves canonical canister state by loan id or short reference.
 
@@ -152,7 +152,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **getConfig**(): `Promise`\<[`InstantLoanConfig`](../interfaces/InstantLoanConfig.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:317](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L317)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:319](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L319)
 
 Returns the active instant-loans canister config via direct query.
 
@@ -168,7 +168,7 @@ Active canister configuration.
 
 > **getEvent**(`eventId`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md) \| `null`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:337](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L337)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:339](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L339)
 
 Returns a single canister event by id via direct query.
 
@@ -192,7 +192,7 @@ The event when found, otherwise `null`.
 
 > **listAccessList**(): `Promise`\<`string`[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:374](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L374)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:376](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L376)
 
 Returns principals authorized for protected update callbacks.
 
@@ -208,7 +208,7 @@ Principal text values on the canister access list.
 
 > **listEvents**(`request`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:355](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L355)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:357](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L357)
 
 Returns a page of canister events via direct query.
 
@@ -232,7 +232,7 @@ Canister events in ascending id order.
 
 > **listWarmedProfiles**(): `Promise`\<[`InstantLoanWarmedProfile`](../interfaces/InstantLoanWarmedProfile.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:409](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L409)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:411](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L411)
 
 Returns warmed profiles currently available for future instant loans.
 

--- a/docs/api-reference/generated/interfaces/CreateAccountData.md
+++ b/docs/api-reference/generated/interfaces/CreateAccountData.md
@@ -18,4 +18,4 @@ Data embedded in a prepared profile-creation action.
 
 Defined in: [packages/client/src/modules/accounts/types.ts:31](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/accounts/types.ts#L31)
 
-Expiry timestamp, in protocol nanoseconds, included in the signed message.
+Unix expiry timestamp in seconds, included in the signed message.

--- a/docs/api-reference/generated/interfaces/CreateBorrowData.md
+++ b/docs/api-reference/generated/interfaces/CreateBorrowData.md
@@ -36,7 +36,7 @@ Amount to borrow in the borrow asset's base units.
 
 Defined in: [packages/client/src/modules/lending/types.ts:119](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/types.ts#L119)
 
-Expiry timestamp, in protocol nanoseconds, included in the signed message.
+Unix expiry timestamp in seconds, included in the signed message.
 
 ***
 

--- a/docs/api-reference/generated/interfaces/CreateWithdrawData.md
+++ b/docs/api-reference/generated/interfaces/CreateWithdrawData.md
@@ -36,7 +36,7 @@ Amount to withdraw in the pool asset's base units.
 
 Defined in: [packages/client/src/modules/lending/types.ts:152](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/types.ts#L152)
 
-Expiry timestamp, in protocol nanoseconds, included in the signed message.
+Unix expiry timestamp in seconds, included in the signed message.
 
 ***
 

--- a/docs/api-reference/generated/interfaces/InstantLoan.md
+++ b/docs/api-reference/generated/interfaces/InstantLoan.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoan
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:391](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L391)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:394](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L394)
 
 Hydrated instant-loan state plus generated quote targets.
 
@@ -16,7 +16,7 @@ Hydrated instant-loan state plus generated quote targets.
 
 > **borrow**: [`InstantLoanBorrow`](InstantLoanBorrow.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:405](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L405)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:408](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L408)
 
 Borrow-side pool, asset, chain, decimals, requested amount, and destination.
 
@@ -26,7 +26,7 @@ Borrow-side pool, asset, chain, decimals, requested amount, and destination.
 
 > **collateral**: [`InstantLoanCollateral`](InstantLoanCollateral.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:403](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L403)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:406](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L406)
 
 Collateral-side pool, asset, chain, decimals, and requested credited amount.
 
@@ -36,7 +36,7 @@ Collateral-side pool, asset, chain, decimals, and requested credited amount.
 
 > **initialDeposit**: [`InstantLoanInitialDeposit`](InstantLoanInitialDeposit.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:409](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L409)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:412](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L412)
 
 Current actionable initial collateral deposit quote.
 
@@ -46,7 +46,7 @@ Current actionable initial collateral deposit quote.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:393](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L393)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:396](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L396)
 
 Canister-assigned loan id.
 
@@ -56,7 +56,7 @@ Canister-assigned loan id.
 
 > **position**: [`InstantLoanPositionSummary`](InstantLoanPositionSummary.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:413](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L413)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:416](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L416)
 
 Current lending position state for the generated profile.
 
@@ -66,7 +66,7 @@ Current lending position state for the generated profile.
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:399](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L399)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:402](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L402)
 
 Generated lending profile principal used by the instant loan.
 
@@ -76,7 +76,7 @@ Generated lending profile principal used by the instant loan.
 
 > **ref**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:395](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L395)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:398](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L398)
 
 Short user-facing reference derived from `loanId`.
 
@@ -86,7 +86,7 @@ Short user-facing reference derived from `loanId`.
 
 > **refundDestination**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:407](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L407)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:410](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L410)
 
 Destination used for collateral refunds or withdrawals.
 
@@ -96,7 +96,7 @@ Destination used for collateral refunds or withdrawals.
 
 > **repayment**: [`InstantLoanRepayment`](InstantLoanRepayment.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:411](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L411)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:414](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L414)
 
 Current repayment quote. Amount fields are zero when the loan has no debt.
 
@@ -106,7 +106,7 @@ Current repayment quote. Amount fields are zero when the loan has no debt.
 
 > **status**: [`InstantLoanStatus`](../type-aliases/InstantLoanStatus.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:397](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L397)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:400](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L400)
 
 Simplified lifecycle status for display and flow control.
 
@@ -116,6 +116,6 @@ Simplified lifecycle status for display and flow control.
 
 > **terms**: [`InstantLoanTerms`](InstantLoanTerms.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:401](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L401)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:404](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L404)
 
 Immutable loan terms.

--- a/docs/api-reference/generated/interfaces/InstantLoan.md
+++ b/docs/api-reference/generated/interfaces/InstantLoan.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoan
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:387](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L387)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:391](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L391)
 
 Hydrated instant-loan state plus generated quote targets.
 
@@ -16,7 +16,7 @@ Hydrated instant-loan state plus generated quote targets.
 
 > **borrow**: [`InstantLoanBorrow`](InstantLoanBorrow.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:401](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L401)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:405](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L405)
 
 Borrow-side pool, asset, chain, decimals, requested amount, and destination.
 
@@ -26,7 +26,7 @@ Borrow-side pool, asset, chain, decimals, requested amount, and destination.
 
 > **collateral**: [`InstantLoanCollateral`](InstantLoanCollateral.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:399](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L399)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:403](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L403)
 
 Collateral-side pool, asset, chain, decimals, and requested credited amount.
 
@@ -36,7 +36,7 @@ Collateral-side pool, asset, chain, decimals, and requested credited amount.
 
 > **initialDeposit**: [`InstantLoanInitialDeposit`](InstantLoanInitialDeposit.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:405](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L405)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:409](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L409)
 
 Current actionable initial collateral deposit quote.
 
@@ -46,7 +46,7 @@ Current actionable initial collateral deposit quote.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:389](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L389)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:393](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L393)
 
 Canister-assigned loan id.
 
@@ -56,7 +56,7 @@ Canister-assigned loan id.
 
 > **position**: [`InstantLoanPositionSummary`](InstantLoanPositionSummary.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:409](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L409)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:413](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L413)
 
 Current lending position state for the generated profile.
 
@@ -66,7 +66,7 @@ Current lending position state for the generated profile.
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:395](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L395)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:399](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L399)
 
 Generated lending profile principal used by the instant loan.
 
@@ -76,7 +76,7 @@ Generated lending profile principal used by the instant loan.
 
 > **ref**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:391](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L391)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:395](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L395)
 
 Short user-facing reference derived from `loanId`.
 
@@ -86,7 +86,7 @@ Short user-facing reference derived from `loanId`.
 
 > **refundDestination**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:403](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L403)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:407](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L407)
 
 Destination used for collateral refunds or withdrawals.
 
@@ -96,7 +96,7 @@ Destination used for collateral refunds or withdrawals.
 
 > **repayment**: [`InstantLoanRepayment`](InstantLoanRepayment.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:407](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L407)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:411](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L411)
 
 Current repayment quote. Amount fields are zero when the loan has no debt.
 
@@ -106,7 +106,7 @@ Current repayment quote. Amount fields are zero when the loan has no debt.
 
 > **status**: [`InstantLoanStatus`](../type-aliases/InstantLoanStatus.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:393](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L393)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:397](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L397)
 
 Simplified lifecycle status for display and flow control.
 
@@ -116,6 +116,6 @@ Simplified lifecycle status for display and flow control.
 
 > **terms**: [`InstantLoanTerms`](InstantLoanTerms.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:397](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L397)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:401](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L401)
 
 Immutable loan terms.

--- a/docs/api-reference/generated/interfaces/InstantLoanBorrow.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanBorrow.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanBorrow
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:375](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L375)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:378](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L378)
 
 Borrow leg selected for an instant loan.
 
@@ -16,7 +16,7 @@ Borrow leg selected for an instant loan.
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:385](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L385)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:388](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L388)
 
 Requested borrow amount in base units.
 
@@ -26,7 +26,7 @@ Requested borrow amount in base units.
 
 > **asset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:379](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L379)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:382](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L382)
 
 Borrow asset symbol.
 
@@ -36,7 +36,7 @@ Borrow asset symbol.
 
 > **chain**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:381](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L381)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:384](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L384)
 
 Chain used for repayment.
 
@@ -46,7 +46,7 @@ Chain used for repayment.
 
 > **decimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:383](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L383)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:386](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L386)
 
 Decimal scale for borrow and debt amounts.
 
@@ -56,7 +56,7 @@ Decimal scale for borrow and debt amounts.
 
 > **destination**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:387](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L387)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:390](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L390)
 
 Destination that receives the borrowed asset.
 
@@ -66,6 +66,6 @@ Destination that receives the borrowed asset.
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:377](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L377)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:380](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L380)
 
 Principal text of the borrow pool.

--- a/docs/api-reference/generated/interfaces/InstantLoanBorrow.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanBorrow.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanBorrow
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:371](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L371)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:375](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L375)
 
 Borrow leg selected for an instant loan.
 
@@ -16,7 +16,7 @@ Borrow leg selected for an instant loan.
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:381](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L381)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:385](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L385)
 
 Requested borrow amount in base units.
 
@@ -26,7 +26,7 @@ Requested borrow amount in base units.
 
 > **asset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:375](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L375)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:379](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L379)
 
 Borrow asset symbol.
 
@@ -36,7 +36,7 @@ Borrow asset symbol.
 
 > **chain**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:377](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L377)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:381](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L381)
 
 Chain used for repayment.
 
@@ -46,7 +46,7 @@ Chain used for repayment.
 
 > **decimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:379](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L379)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:383](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L383)
 
 Decimal scale for borrow and debt amounts.
 
@@ -56,7 +56,7 @@ Decimal scale for borrow and debt amounts.
 
 > **destination**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:383](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L383)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:387](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L387)
 
 Destination that receives the borrowed asset.
 
@@ -66,6 +66,6 @@ Destination that receives the borrowed asset.
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:373](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L373)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:377](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L377)
 
 Principal text of the borrow pool.

--- a/docs/api-reference/generated/interfaces/InstantLoanBorrowRequestedEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanBorrowRequestedEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanBorrowRequestedEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:218](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L218)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:220](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L220)
 
 Borrow request event payload.
 
@@ -16,7 +16,7 @@ Borrow request event payload.
 
 > **account**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:221](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L221)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:223](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L223)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:221](https://git
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:223](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L223)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:225](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L225)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:223](https://git
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:220](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L220)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:222](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L222)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:220](https://git
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:222](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L222)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:224](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L224)
 
 ***
 
@@ -48,4 +48,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:222](https://git
 
 > **type**: `"BorrowRequested"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:219](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L219)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:221](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L221)

--- a/docs/api-reference/generated/interfaces/InstantLoanCandidate.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanCandidate.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanCandidate
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:422](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L422)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:425](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L425)
 
 Discovery result returned by address lookup.
 
@@ -19,7 +19,7 @@ Candidates are intentionally lightweight; call `instantLoans.get(...)` with
 
 > **borrowAsset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:438](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L438)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:441](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L441)
 
 Borrow asset symbol.
 
@@ -29,7 +29,7 @@ Borrow asset symbol.
 
 > **borrowPoolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:434](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L434)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:437](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L437)
 
 Principal text of the borrow pool.
 
@@ -39,7 +39,7 @@ Principal text of the borrow pool.
 
 > **collateralAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:440](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L440)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:443](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L443)
 
 Collateral amount in base units.
 
@@ -49,7 +49,7 @@ Collateral amount in base units.
 
 > **collateralAsset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:436](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L436)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:439](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L439)
 
 Collateral asset symbol.
 
@@ -59,7 +59,7 @@ Collateral asset symbol.
 
 > **collateralPoolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:432](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L432)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:435](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L435)
 
 Principal text of the collateral pool.
 
@@ -69,7 +69,7 @@ Principal text of the collateral pool.
 
 > `optional` **createdAt?**: `Date`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:430](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L430)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:433](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L433)
 
 API-observed creation time, if provided by the indexer.
 
@@ -79,7 +79,7 @@ API-observed creation time, if provided by the indexer.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:424](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L424)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:427](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L427)
 
 Canister-assigned loan id.
 
@@ -89,7 +89,7 @@ Canister-assigned loan id.
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:428](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L428)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:431](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L431)
 
 Generated lending profile principal used by the instant loan.
 
@@ -99,6 +99,6 @@ Generated lending profile principal used by the instant loan.
 
 > **ref**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:426](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L426)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:429](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L429)
 
 Short user-facing reference derived from `loanId`.

--- a/docs/api-reference/generated/interfaces/InstantLoanCandidate.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanCandidate.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanCandidate
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:418](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L418)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:422](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L422)
 
 Discovery result returned by address lookup.
 
@@ -19,7 +19,7 @@ Candidates are intentionally lightweight; call `instantLoans.get(...)` with
 
 > **borrowAsset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:434](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L434)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:438](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L438)
 
 Borrow asset symbol.
 
@@ -29,7 +29,7 @@ Borrow asset symbol.
 
 > **borrowPoolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:430](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L430)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:434](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L434)
 
 Principal text of the borrow pool.
 
@@ -39,7 +39,7 @@ Principal text of the borrow pool.
 
 > **collateralAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:436](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L436)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:440](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L440)
 
 Collateral amount in base units.
 
@@ -49,7 +49,7 @@ Collateral amount in base units.
 
 > **collateralAsset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:432](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L432)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:436](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L436)
 
 Collateral asset symbol.
 
@@ -59,7 +59,7 @@ Collateral asset symbol.
 
 > **collateralPoolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:428](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L428)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:432](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L432)
 
 Principal text of the collateral pool.
 
@@ -69,7 +69,7 @@ Principal text of the collateral pool.
 
 > `optional` **createdAt?**: `Date`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:426](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L426)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:430](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L430)
 
 API-observed creation time, if provided by the indexer.
 
@@ -79,7 +79,7 @@ API-observed creation time, if provided by the indexer.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:420](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L420)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:424](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L424)
 
 Canister-assigned loan id.
 
@@ -89,7 +89,7 @@ Canister-assigned loan id.
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:424](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L424)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:428](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L428)
 
 Generated lending profile principal used by the instant loan.
 
@@ -99,6 +99,6 @@ Generated lending profile principal used by the instant loan.
 
 > **ref**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:422](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L422)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:426](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L426)
 
 Short user-facing reference derived from `loanId`.

--- a/docs/api-reference/generated/interfaces/InstantLoanCollateral.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanCollateral.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanCollateral
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:357](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L357)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:361](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L361)
 
 Collateral leg selected for an instant loan.
 
@@ -16,7 +16,7 @@ Collateral leg selected for an instant loan.
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:367](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L367)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:371](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L371)
 
 Intended credited collateral amount in base units, before inflow fees.
 
@@ -26,7 +26,7 @@ Intended credited collateral amount in base units, before inflow fees.
 
 > **asset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:361](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L361)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:365](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L365)
 
 Collateral asset symbol.
 
@@ -36,7 +36,7 @@ Collateral asset symbol.
 
 > **chain**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:363](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L363)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:367](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L367)
 
 Chain used for collateral deposits.
 
@@ -46,7 +46,7 @@ Chain used for collateral deposits.
 
 > **decimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:365](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L365)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:369](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L369)
 
 Decimal scale for collateral amounts.
 
@@ -56,6 +56,6 @@ Decimal scale for collateral amounts.
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:359](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L359)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:363](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L363)
 
 Principal text of the collateral pool.

--- a/docs/api-reference/generated/interfaces/InstantLoanCollateral.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanCollateral.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanCollateral
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:361](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L361)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:364](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L364)
 
 Collateral leg selected for an instant loan.
 
@@ -16,7 +16,7 @@ Collateral leg selected for an instant loan.
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:371](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L371)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:374](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L374)
 
 Intended credited collateral amount in base units, before inflow fees.
 
@@ -26,7 +26,7 @@ Intended credited collateral amount in base units, before inflow fees.
 
 > **asset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:365](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L365)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:368](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L368)
 
 Collateral asset symbol.
 
@@ -36,7 +36,7 @@ Collateral asset symbol.
 
 > **chain**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:367](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L367)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:370](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L370)
 
 Chain used for collateral deposits.
 
@@ -46,7 +46,7 @@ Chain used for collateral deposits.
 
 > **decimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:369](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L369)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:372](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L372)
 
 Decimal scale for collateral amounts.
 
@@ -56,6 +56,6 @@ Decimal scale for collateral amounts.
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:363](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L363)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:366](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L366)
 
 Principal text of the collateral pool.

--- a/docs/api-reference/generated/interfaces/InstantLoanCreatedEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanCreatedEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanCreatedEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:194](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L194)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:196](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L196)
 
 Loan-created instant-loan event payload.
 
@@ -16,7 +16,7 @@ Loan-created instant-loan event payload.
 
 > **borrowAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:199](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L199)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:201](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L201)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:199](https://git
 
 > **borrowAsset**: [`InstantLoanAsset`](../type-aliases/InstantLoanAsset.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:206](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L206)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:208](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L208)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:206](https://git
 
 > **borrowDestination**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:197](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L197)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:199](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L199)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:197](https://git
 
 > **borrowPoolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:205](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L205)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:207](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L207)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:205](https://git
 
 > **collateralAsset**: [`InstantLoanAsset`](../type-aliases/InstantLoanAsset.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:198](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L198)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:200](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L200)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:198](https://git
 
 > **collateralPoolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:200](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L200)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:202](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L202)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:200](https://git
 
 > **depositWindowSeconds**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:203](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L203)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:205](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L205)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:203](https://git
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:196](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L196)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:198](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L198)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:196](https://git
 
 > **ltvMaxBps**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:202](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L202)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:204](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L204)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:202](https://git
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:204](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L204)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:206](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L206)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:204](https://git
 
 > **refundDestination**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:201](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L201)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:203](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L203)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:201](https://git
 
 > **type**: `"LoanCreated"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:195](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L195)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:197](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L197)

--- a/docs/api-reference/generated/interfaces/InstantLoanDepositTimerExceededEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanDepositTimerExceededEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanDepositTimerExceededEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:227](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L227)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:229](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L229)
 
 Deposit timer exceeded event payload.
 
@@ -16,7 +16,7 @@ Deposit timer exceeded event payload.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:229](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L229)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:231](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L231)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:229](https://git
 
 > **type**: `"DepositTimerExceeded"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:228](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L228)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:230](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L230)

--- a/docs/api-reference/generated/interfaces/InstantLoanDepositTimerStartedEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanDepositTimerStartedEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanDepositTimerStartedEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:259](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L259)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:261](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L261)
 
 Deposit timer started event payload.
 
@@ -16,7 +16,7 @@ Deposit timer started event payload.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:261](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L261)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:263](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L263)
 
 ***
 
@@ -24,7 +24,9 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:261](https://git
 
 > **timestamp**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:262](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L262)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:265](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L265)
+
+Unix timestamp in seconds when the deposit timer started.
 
 ***
 
@@ -32,4 +34,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:262](https://git
 
 > **type**: `"DepositTimerStarted"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:260](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L260)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:262](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L262)

--- a/docs/api-reference/generated/interfaces/InstantLoanEvent.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanEvent.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanEvent
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:183](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L183)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:184](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L184)
 
 Direct canister event returned by the instant-loans query API.
 
@@ -16,7 +16,7 @@ Direct canister event returned by the instant-loans query API.
 
 > **eventType**: [`InstantLoanEventType`](../type-aliases/InstantLoanEventType.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:187](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L187)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:189](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L189)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:187](https://git
 
 > **id**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:184](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L184)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:185](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L185)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:184](https://git
 
 > **schemaVersion**: `number`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:185](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L185)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:186](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L186)
 
 ***
 
@@ -40,4 +40,6 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:185](https://git
 
 > **timestamp**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:186](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L186)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:188](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L188)
+
+Unix event timestamp in seconds.

--- a/docs/api-reference/generated/interfaces/InstantLoanFullLendWithdrawalRequestedEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanFullLendWithdrawalRequestedEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanFullLendWithdrawalRequestedEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:210](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L210)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:212](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L212)
 
 Full collateral withdrawal request event payload.
 
@@ -16,7 +16,7 @@ Full collateral withdrawal request event payload.
 
 > **account**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:213](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L213)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:215](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L215)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:213](https://git
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:212](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L212)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:214](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L214)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:212](https://git
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:214](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L214)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:216](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L216)
 
 ***
 
@@ -40,4 +40,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:214](https://git
 
 > **type**: `"FullLendWithdrawalRequested"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:211](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L211)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:213](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L213)

--- a/docs/api-reference/generated/interfaces/InstantLoanInitialDeposit.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanInitialDeposit.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanInitialDeposit
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:301](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L301)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:304](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L304)
 
 Initial collateral deposit quote returned when an instant loan is created.
 
@@ -16,7 +16,7 @@ Initial collateral deposit quote returned when an instant loan is created.
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:303](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L303)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:306](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L306)
 
 Full amount to send to the deposit target, including the estimated inflow fee.
 
@@ -26,7 +26,7 @@ Full amount to send to the deposit target, including the estimated inflow fee.
 
 > **asset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:311](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L311)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:314](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L314)
 
 Collateral asset to deposit.
 
@@ -36,7 +36,7 @@ Collateral asset to deposit.
 
 > **chain**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:313](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L313)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:316](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L316)
 
 Chain used for the collateral deposit.
 
@@ -46,7 +46,7 @@ Chain used for the collateral deposit.
 
 > **collateralAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:307](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L307)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:310](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L310)
 
 Intended credited collateral amount in base units, before inflow fees.
 
@@ -56,7 +56,7 @@ Intended credited collateral amount in base units, before inflow fees.
 
 > **decimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:305](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L305)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:308](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L308)
 
 Decimal scale for `amount`, `collateralAmount`, and `inflowFeeAmount`.
 
@@ -66,7 +66,7 @@ Decimal scale for `amount`, `collateralAmount`, and `inflowFeeAmount`.
 
 > **detectedTimestamp**: `bigint` \| `null`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:317](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L317)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:320](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L320)
 
 Unix timestamp in seconds when the collateral deposit was detected, or null before detection.
 
@@ -76,7 +76,7 @@ Unix timestamp in seconds when the collateral deposit was detected, or null befo
 
 > **expiryTimestamp**: `bigint` \| `null`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:319](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L319)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:322](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L322)
 
 Unix timestamp in seconds when the collateral deposit window expires, or null when unavailable.
 
@@ -86,7 +86,7 @@ Unix timestamp in seconds when the collateral deposit window expires, or null wh
 
 > **inflowFeeAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:309](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L309)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:312](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L312)
 
 Inflow fee amount in base units added to the transfer amount.
 
@@ -96,6 +96,6 @@ Inflow fee amount in base units added to the transfer amount.
 
 > **target**: [`SupplyTarget`](../type-aliases/SupplyTarget.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:315](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L315)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:318](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L318)
 
 Address or ICRC account where the collateral should be sent.

--- a/docs/api-reference/generated/interfaces/InstantLoanInitialDeposit.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanInitialDeposit.md
@@ -78,7 +78,7 @@ Unix timestamp in seconds when the collateral deposit was detected, or null befo
 
 Defined in: [packages/client/src/modules/instant-loans/types.ts:322](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L322)
 
-Unix timestamp in seconds when the collateral deposit window expires, or null when unavailable.
+Unix timestamp in seconds when the collateral deposit window expires, or null before detection when unavailable.
 
 ***
 

--- a/docs/api-reference/generated/interfaces/InstantLoanInitialDeposit.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanInitialDeposit.md
@@ -62,6 +62,26 @@ Decimal scale for `amount`, `collateralAmount`, and `inflowFeeAmount`.
 
 ***
 
+### detectedTimestamp
+
+> **detectedTimestamp**: `bigint` \| `null`
+
+Defined in: [packages/client/src/modules/instant-loans/types.ts:317](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L317)
+
+Unix timestamp in seconds when the collateral deposit was detected, or null before detection.
+
+***
+
+### expiryTimestamp
+
+> **expiryTimestamp**: `bigint` \| `null`
+
+Defined in: [packages/client/src/modules/instant-loans/types.ts:319](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L319)
+
+Unix timestamp in seconds when the collateral deposit window expires, or null when unavailable.
+
+***
+
 ### inflowFeeAmount
 
 > **inflowFeeAmount**: `bigint`

--- a/docs/api-reference/generated/interfaces/InstantLoanPositionSummary.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanPositionSummary.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanPositionSummary
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:319](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L319)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:323](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L323)
 
 Current lending position backing the instant loan.
 
@@ -16,7 +16,7 @@ Current lending position backing the instant loan.
 
 > **borrowedAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:327](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L327)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:331](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L331)
 
 Borrowed principal in the borrow asset's base units.
 
@@ -26,7 +26,7 @@ Borrowed principal in the borrow asset's base units.
 
 > **borrowedDecimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:329](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L329)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:333](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L333)
 
 Decimal scale for borrowed/debt amounts.
 
@@ -36,7 +36,7 @@ Decimal scale for borrowed/debt amounts.
 
 > **collateralAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:321](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L321)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:325](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L325)
 
 Current collateral amount in the collateral asset's base units.
 
@@ -46,7 +46,7 @@ Current collateral amount in the collateral asset's base units.
 
 > **collateralDecimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:323](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L323)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:327](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L327)
 
 Decimal scale for `collateralAmount`.
 
@@ -56,7 +56,7 @@ Decimal scale for `collateralAmount`.
 
 > **collateralInterestAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:325](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L325)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:329](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L329)
 
 Earned interest on the collateral side in base units.
 
@@ -66,7 +66,7 @@ Earned interest on the collateral side in base units.
 
 > **debtInterestAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:331](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L331)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:335](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L335)
 
 Accrued borrow interest in base units.
 
@@ -76,6 +76,6 @@ Accrued borrow interest in base units.
 
 > **totalDebtAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:333](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L333)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:337](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L337)
 
 Borrowed principal plus accrued interest in base units, before repayment buffer.

--- a/docs/api-reference/generated/interfaces/InstantLoanPositionSummary.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanPositionSummary.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanPositionSummary
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:323](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L323)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:326](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L326)
 
 Current lending position backing the instant loan.
 
@@ -16,7 +16,7 @@ Current lending position backing the instant loan.
 
 > **borrowedAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:331](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L331)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:334](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L334)
 
 Borrowed principal in the borrow asset's base units.
 
@@ -26,7 +26,7 @@ Borrowed principal in the borrow asset's base units.
 
 > **borrowedDecimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:333](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L333)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:336](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L336)
 
 Decimal scale for borrowed/debt amounts.
 
@@ -36,7 +36,7 @@ Decimal scale for borrowed/debt amounts.
 
 > **collateralAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:325](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L325)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:328](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L328)
 
 Current collateral amount in the collateral asset's base units.
 
@@ -46,7 +46,7 @@ Current collateral amount in the collateral asset's base units.
 
 > **collateralDecimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:327](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L327)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:330](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L330)
 
 Decimal scale for `collateralAmount`.
 
@@ -56,7 +56,7 @@ Decimal scale for `collateralAmount`.
 
 > **collateralInterestAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:329](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L329)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:332](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L332)
 
 Earned interest on the collateral side in base units.
 
@@ -66,7 +66,7 @@ Earned interest on the collateral side in base units.
 
 > **debtInterestAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:335](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L335)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:338](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L338)
 
 Accrued borrow interest in base units.
 
@@ -76,6 +76,6 @@ Accrued borrow interest in base units.
 
 > **totalDebtAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:337](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L337)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:340](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L340)
 
 Borrowed principal plus accrued interest in base units, before repayment buffer.

--- a/docs/api-reference/generated/interfaces/InstantLoanProfileWarmedEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanProfileWarmedEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanProfileWarmedEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:243](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L243)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:245](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L245)
 
 Profile-warmed event payload.
 
@@ -16,7 +16,7 @@ Profile-warmed event payload.
 
 > **derivationIndex**: `Uint8Array`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:245](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L245)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:247](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L247)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:245](https://git
 
 > **ethAddress**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:247](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L247)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:249](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L249)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:247](https://git
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:248](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L248)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:250](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L250)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:248](https://git
 
 > **type**: `"ProfileWarmed"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:244](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L244)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:246](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L246)
 
 ***
 
@@ -48,4 +48,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:244](https://git
 
 > **warmedProfileId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:246](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L246)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:248](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L248)

--- a/docs/api-reference/generated/interfaces/InstantLoanRepayCompleteEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanRepayCompleteEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanRepayCompleteEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:252](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L252)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:254](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L254)
 
 Repay-complete event payload.
 
@@ -16,7 +16,7 @@ Repay-complete event payload.
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:254](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L254)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:256](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L256)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:254](https://git
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:255](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L255)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:257](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L257)
 
 ***
 
@@ -32,4 +32,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:255](https://git
 
 > **type**: `"RepayComplete"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:253](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L253)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:255](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L255)

--- a/docs/api-reference/generated/interfaces/InstantLoanRepayment.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanRepayment.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanRepayment
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:277](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L277)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:280](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L280)
 
 Current amount to send to the repayment target to close the debt.
 
@@ -16,7 +16,7 @@ Current amount to send to the repayment target to close the debt.
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:279](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L279)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:282](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L282)
 
 Full amount to send to the repayment target, including fee and interest buffer.
 
@@ -26,7 +26,7 @@ Full amount to send to the repayment target, including fee and interest buffer.
 
 > **asset**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:293](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L293)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:296](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L296)
 
 Asset to repay.
 
@@ -36,7 +36,7 @@ Asset to repay.
 
 > **chain**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:295](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L295)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:298](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L298)
 
 Chain used for repayment.
 
@@ -46,7 +46,7 @@ Chain used for repayment.
 
 > **debtAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:283](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L283)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:286](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L286)
 
 Current debt in base units, before fee and interest buffer.
 
@@ -56,7 +56,7 @@ Current debt in base units, before fee and interest buffer.
 
 > **decimals**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:281](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L281)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:284](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L284)
 
 Decimal scale for `amount`.
 
@@ -66,7 +66,7 @@ Decimal scale for `amount`.
 
 > **inflowFeeAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:289](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L289)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:292](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L292)
 
 Inflow fee amount in base units added to the repayment transfer. Falls back to the protocol minimum when live estimation is unavailable.
 
@@ -76,7 +76,7 @@ Inflow fee amount in base units added to the repayment transfer. Falls back to t
 
 > **inflowFeeEstimateAvailable**: `boolean`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:291](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L291)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:294](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L294)
 
 Whether `inflowFeeAmount` came from a live fee estimate.
 
@@ -86,7 +86,7 @@ Whether `inflowFeeAmount` came from a live fee estimate.
 
 > **interestBufferAmount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:285](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L285)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:288](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L288)
 
 Additional interest buffer in base units.
 
@@ -96,7 +96,7 @@ Additional interest buffer in base units.
 
 > **interestBufferSeconds**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:287](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L287)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:290](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L290)
 
 Seconds of interest accrual included in `interestBufferAmount`.
 
@@ -106,6 +106,6 @@ Seconds of interest accrual included in `interestBufferAmount`.
 
 > **target**: [`SupplyTarget`](../type-aliases/SupplyTarget.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:297](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L297)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:300](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L300)
 
 Address or ICRC account where the repayment should be sent.

--- a/docs/api-reference/generated/interfaces/InstantLoanStuckFundsWithdrawalRequestedEventType.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanStuckFundsWithdrawalRequestedEventType.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanStuckFundsWithdrawalRequestedEventType
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:233](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L233)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:235](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L235)
 
 Stuck funds withdrawal request event payload.
 
@@ -16,7 +16,7 @@ Stuck funds withdrawal request event payload.
 
 > **account**: [`InstantLoanAccount`](../type-aliases/InstantLoanAccount.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:237](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L237)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:239](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L239)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:237](https://git
 
 > **amount**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:239](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L239)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:241](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L241)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:239](https://git
 
 > **leg**: [`InstantLoanLeg`](../type-aliases/InstantLoanLeg.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:235](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L235)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:237](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L237)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:235](https://git
 
 > **loanId**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:236](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L236)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:238](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L238)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:236](https://git
 
 > **poolId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:238](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L238)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:240](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L240)
 
 ***
 
@@ -56,4 +56,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:238](https://git
 
 > **type**: `"StuckFundsWithdrawalRequested"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:234](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L234)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:236](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L236)

--- a/docs/api-reference/generated/interfaces/InstantLoanTerms.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanTerms.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanTerms
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:349](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L349)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:353](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L353)
 
 Immutable terms selected for an instant loan.
 
@@ -16,7 +16,7 @@ Immutable terms selected for an instant loan.
 
 > **depositWindowSeconds**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:353](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L353)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:357](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L357)
 
 Seconds allowed for the collateral deposit before timeout.
 
@@ -26,6 +26,6 @@ Seconds allowed for the collateral deposit before timeout.
 
 > **ltvMaxBps**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:351](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L351)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:355](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L355)
 
 Maximum loan-to-value ratio in basis points.

--- a/docs/api-reference/generated/interfaces/InstantLoanTerms.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanTerms.md
@@ -6,7 +6,7 @@
 
 # Interface: InstantLoanTerms
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:353](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L353)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:356](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L356)
 
 Immutable terms selected for an instant loan.
 
@@ -16,7 +16,7 @@ Immutable terms selected for an instant loan.
 
 > **depositWindowSeconds**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:357](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L357)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:360](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L360)
 
 Seconds allowed for the collateral deposit before timeout.
 
@@ -26,6 +26,6 @@ Seconds allowed for the collateral deposit before timeout.
 
 > **ltvMaxBps**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:355](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L355)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:358](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L358)
 
 Maximum loan-to-value ratio in basis points.

--- a/docs/api-reference/generated/interfaces/InstantLoanWarmedProfile.md
+++ b/docs/api-reference/generated/interfaces/InstantLoanWarmedProfile.md
@@ -24,7 +24,9 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:177](https://git
 
 > **createdAt**: `bigint`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:178](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L178)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:179](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L179)
+
+Unix creation timestamp in seconds.
 
 ***
 
@@ -40,4 +42,4 @@ Defined in: [packages/client/src/modules/instant-loans/types.ts:176](https://git
 
 > **profileId**: `string`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:179](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L179)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:180](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L180)

--- a/docs/api-reference/generated/interfaces/Pool.md
+++ b/docs/api-reference/generated/interfaces/Pool.md
@@ -118,7 +118,7 @@ Pool canister principal text.
 
 Defined in: [packages/client/src/modules/market/types.ts:58](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/types.ts#L58)
 
-Last pool update timestamp when available.
+Unix timestamp in seconds of the last pool update when available.
 
 ***
 

--- a/docs/api-reference/generated/interfaces/Position.md
+++ b/docs/api-reference/generated/interfaces/Position.md
@@ -88,7 +88,7 @@ Accrued supply interest in base units.
 
 Defined in: [packages/client/src/modules/positions/types.ts:23](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/types.ts#L23)
 
-Protocol timestamp of the last position update.
+Unix timestamp in seconds of the last position update.
 
 ***
 

--- a/docs/api-reference/generated/type-aliases/InstantLoanEventType.md
+++ b/docs/api-reference/generated/type-aliases/InstantLoanEventType.md
@@ -8,6 +8,6 @@
 
 > **InstantLoanEventType** = [`InstantLoanCreatedEventType`](../interfaces/InstantLoanCreatedEventType.md) \| [`InstantLoanFullLendWithdrawalRequestedEventType`](../interfaces/InstantLoanFullLendWithdrawalRequestedEventType.md) \| [`InstantLoanBorrowRequestedEventType`](../interfaces/InstantLoanBorrowRequestedEventType.md) \| [`InstantLoanDepositTimerExceededEventType`](../interfaces/InstantLoanDepositTimerExceededEventType.md) \| [`InstantLoanStuckFundsWithdrawalRequestedEventType`](../interfaces/InstantLoanStuckFundsWithdrawalRequestedEventType.md) \| [`InstantLoanProfileWarmedEventType`](../interfaces/InstantLoanProfileWarmedEventType.md) \| [`InstantLoanRepayCompleteEventType`](../interfaces/InstantLoanRepayCompleteEventType.md) \| [`InstantLoanDepositTimerStartedEventType`](../interfaces/InstantLoanDepositTimerStartedEventType.md)
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:266](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L266)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:269](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L269)
 
 Direct canister event payload returned by instant-loans event queries.

--- a/docs/api-reference/generated/type-aliases/InstantLoanLeg.md
+++ b/docs/api-reference/generated/type-aliases/InstantLoanLeg.md
@@ -8,6 +8,6 @@
 
 > **InstantLoanLeg** = `"Lend"` \| `"Borrow"`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:191](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L191)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:193](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L193)
 
 Instant-loan leg used when stuck funds are withdrawn.

--- a/docs/api-reference/generated/type-aliases/InstantLoanStatus.md
+++ b/docs/api-reference/generated/type-aliases/InstantLoanStatus.md
@@ -8,6 +8,6 @@
 
 > **InstantLoanStatus** = *typeof* [`InstantLoanStatus`](../variables/InstantLoanStatus.md)\[keyof *typeof* [`InstantLoanStatus`](../variables/InstantLoanStatus.md)\]
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:341](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L341)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:344](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L344)
 
 Simplified lifecycle status for consumer UIs.

--- a/docs/api-reference/generated/type-aliases/InstantLoanStatus.md
+++ b/docs/api-reference/generated/type-aliases/InstantLoanStatus.md
@@ -8,6 +8,6 @@
 
 > **InstantLoanStatus** = *typeof* [`InstantLoanStatus`](../variables/InstantLoanStatus.md)\[keyof *typeof* [`InstantLoanStatus`](../variables/InstantLoanStatus.md)\]
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:337](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L337)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:341](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L341)
 
 Simplified lifecycle status for consumer UIs.

--- a/docs/api-reference/generated/variables/InstantLoanStatus.md
+++ b/docs/api-reference/generated/variables/InstantLoanStatus.md
@@ -8,7 +8,7 @@
 
 > `const` **InstantLoanStatus**: `object`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:341](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L341)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:344](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L344)
 
 Simplified lifecycle status for consumer UIs.
 

--- a/docs/api-reference/generated/variables/InstantLoanStatus.md
+++ b/docs/api-reference/generated/variables/InstantLoanStatus.md
@@ -8,7 +8,7 @@
 
 > `const` **InstantLoanStatus**: `object`
 
-Defined in: [packages/client/src/modules/instant-loans/types.ts:337](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L337)
+Defined in: [packages/client/src/modules/instant-loans/types.ts:341](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/types.ts#L341)
 
 Simplified lifecycle status for consumer UIs.
 

--- a/examples/instant-loans-flow/src/App.tsx
+++ b/examples/instant-loans-flow/src/App.tsx
@@ -7,6 +7,7 @@ import {
   formatInstantLoan,
   formatPercentFromBps,
   formatPool,
+  formatUnixTimestampSeconds,
   getRecentLoanRefs,
   parseAmountToBaseUnits,
   parsePercentToBps,
@@ -159,6 +160,12 @@ export function App() {
           loan.initialDeposit.inflowFeeAmount,
           loan.initialDeposit.decimals
         )} ${collateralPool.asset}`,
+        `Deposit detected: ${formatUnixTimestampSeconds(
+          loan.initialDeposit.detectedTimestamp
+        )}`,
+        `Deposit expires: ${formatUnixTimestampSeconds(
+          loan.initialDeposit.expiryTimestamp
+        )}`,
         `Borrow amount: ${formatAmount(
           parsedBorrowAmount,
           borrowPool.decimals

--- a/examples/instant-loans-flow/src/format.ts
+++ b/examples/instant-loans-flow/src/format.ts
@@ -10,6 +10,7 @@ import type {
 const DISPLAY_DECIMALS = 6;
 const PERCENT_DECIMALS = 2n;
 const PERCENT_SCALE = 100n;
+const MILLISECONDS_PER_SECOND = 1_000n;
 const RECENT_LOANS_STORAGE_KEY = "liquidium-instant-loans.recentRefs";
 const MAX_RECENT_LOANS = 10;
 const ERROR_FIELD_EXCLUDE_LIST = new Set(["name", "message", "stack", "cause"]);
@@ -116,6 +117,20 @@ export function formatPercentFromBps(value: bigint): string {
   return `${formatAmount(value, 2n)}%`;
 }
 
+export function formatUnixTimestampSeconds(
+  timestampSeconds: bigint | null
+): string {
+  if (timestampSeconds === null) {
+    return "not set";
+  }
+
+  const timestampMilliseconds = Number(
+    timestampSeconds * MILLISECONDS_PER_SECOND
+  );
+
+  return `${timestampSeconds.toString()} (${new Date(timestampMilliseconds).toISOString()})`;
+}
+
 export function formatPool(pool: Pool): string {
   return [
     `${pool.asset} on ${pool.chain}`,
@@ -216,6 +231,12 @@ export function formatInstantLoan(
       loan.initialDeposit.inflowFeeAmount,
       collateralDecimals
     )} ${loan.initialDeposit.asset}`,
+    `Deposit detected: ${formatUnixTimestampSeconds(
+      loan.initialDeposit.detectedTimestamp
+    )}`,
+    `Deposit expires: ${formatUnixTimestampSeconds(
+      loan.initialDeposit.expiryTimestamp
+    )}`,
     "",
     "Current position:",
     `Collateral: ${formatAmount(

--- a/examples/sdk-method-query/README.md
+++ b/examples/sdk-method-query/README.md
@@ -47,4 +47,5 @@ history, quote, lending, and instant-loan methods:
 - `instantLoans.findByAddress`
 
 `instantLoans.get(...)` returns current loan state plus generated targets,
-position state, and the actionable repayment amount.
+initial deposit detection/expiry timestamps, position state, and the actionable
+repayment amount.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -224,7 +224,7 @@ Most instant-loan UIs show or store these fields:
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
 | `loan.initialDeposit.detectedTimestamp` | Unix timestamp in seconds when the collateral deposit was detected, or `null` before detection |
-| `loan.initialDeposit.expiryTimestamp` | Unix timestamp in seconds when the collateral deposit window expires, or `null` when unavailable |
+| `loan.initialDeposit.expiryTimestamp` | Unix timestamp in seconds when the collateral deposit window expires, or `null` before detection when unavailable |
 | `loan.repayment.amount` | Full amount to repay, including fee and interest buffer. Zero when no repayment is due |
 | `loan.repayment.target` | Address or ICRC account where the user sends repayment |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -223,6 +223,8 @@ Most instant-loan UIs show or store these fields:
 | `loan.initialDeposit.amount` | Fee-inclusive collateral amount to send after creation or restore |
 | `loan.initialDeposit.collateralAmount` | Intended credited collateral target used for LTV |
 | `loan.initialDeposit.target` | Address or ICRC account where the user sends collateral |
+| `loan.initialDeposit.detectedTimestamp` | Unix timestamp in seconds when the collateral deposit was detected, or `null` before detection |
+| `loan.initialDeposit.expiryTimestamp` | Unix timestamp in seconds when the collateral deposit window expires, or `null` when unavailable |
 | `loan.repayment.amount` | Full amount to repay, including fee and interest buffer. Zero when no repayment is due |
 | `loan.repayment.target` | Address or ICRC account where the user sends repayment |
 | `loan.position` | Current collateral, debt, and interest state for the generated profile |

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4224,7 +4224,16 @@ describe("InstantLoansModule", () => {
 
   test("gets canonical loan state by ref and derives flow targets", async () => {
     // given
-    const getLoan = vi.fn().mockResolvedValue({ Ok: createInstantLoan() });
+    const DEPOSIT_DETECTED_TIMESTAMP = 1_775_232_000n;
+    const EXPIRY_TIMESTAMP = 1_775_235_600n;
+    const DEPOSIT_DETECTED_AT_NS = DEPOSIT_DETECTED_TIMESTAMP * 1_000_000_000n;
+    const EXPIRES_AT_NS = EXPIRY_TIMESTAMP * 1_000_000_000n;
+    const getLoan = vi.fn().mockResolvedValue({
+      Ok: createInstantLoan({
+        deposit_detected_ts: [DEPOSIT_DETECTED_AT_NS],
+        expires_at: [EXPIRES_AT_NS],
+      }),
+    });
     const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
     const getDepositAddress = vi.fn().mockResolvedValue({
       Ok: "0x1111111111111111111111111111111111111111",
@@ -4322,6 +4331,8 @@ describe("InstantLoansModule", () => {
       inflowFeeAmount: 2_500n,
       asset: "BTC",
       chain: "BTC",
+      detectedTimestamp: DEPOSIT_DETECTED_TIMESTAMP,
+      expiryTimestamp: EXPIRY_TIMESTAMP,
       target: expect.objectContaining({
         address: "bc1qinstantdeposit",
       }),
@@ -5144,7 +5155,7 @@ describe("InstantLoansModule", () => {
     );
   });
 
-  function createInstantLoan() {
+  function createInstantLoan(overrides: Record<string, unknown> = {}) {
     return {
       id: LOAN_ID,
       authorisation: {
@@ -5171,6 +5182,7 @@ describe("InstantLoansModule", () => {
       borrow_asset: { USDT: null },
       expires_at: [],
       deposit_detected_ts: [],
+      ...overrides,
     };
   }
 

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -2,6 +2,7 @@ import { Actor } from "@icp-sdk/core/agent";
 import { Principal } from "@icp-sdk/core/principal";
 import { decodeFunctionData } from "viem";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import type { InstantLoanCanisterRecord } from "../core/canisters/instant-loans/actor";
 import { DEFAULT_API_BASE_URL } from "../core/config";
 import { CK_DEPOSIT_ABI, ERC20_ABI } from "../core/evm";
 import { encodeInflowSubaccount } from "../core/utils/inflow-subaccount";
@@ -4224,12 +4225,12 @@ describe("InstantLoansModule", () => {
 
   test("gets canonical loan state by ref and derives flow targets", async () => {
     // given
-    const DEPOSIT_DETECTED_TIMESTAMP = 1_775_232_000n;
-    const EXPIRY_TIMESTAMP = 1_775_235_600n;
+    const DEPOSIT_DETECTED_TIMESTAMP_SECONDS = 1_775_232_000n;
+    const EXPIRY_TIMESTAMP_SECONDS = 1_775_235_600n;
     const getLoan = vi.fn().mockResolvedValue({
       Ok: createInstantLoan({
-        deposit_detected_ts: [DEPOSIT_DETECTED_TIMESTAMP],
-        expires_at: [EXPIRY_TIMESTAMP],
+        deposit_detected_ts: [DEPOSIT_DETECTED_TIMESTAMP_SECONDS],
+        expires_at: [EXPIRY_TIMESTAMP_SECONDS],
       }),
     });
     const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
@@ -4329,8 +4330,8 @@ describe("InstantLoansModule", () => {
       inflowFeeAmount: 2_500n,
       asset: "BTC",
       chain: "BTC",
-      detectedTimestamp: DEPOSIT_DETECTED_TIMESTAMP,
-      expiryTimestamp: EXPIRY_TIMESTAMP,
+      detectedTimestamp: DEPOSIT_DETECTED_TIMESTAMP_SECONDS,
+      expiryTimestamp: EXPIRY_TIMESTAMP_SECONDS,
       target: expect.objectContaining({
         address: "bc1qinstantdeposit",
       }),
@@ -4661,42 +4662,39 @@ describe("InstantLoansModule", () => {
     expect(estimateDepositFee).not.toHaveBeenCalled();
   });
 
-  test("creates a loan through the default SDK API without calling the instant-loans canister", async () => {
+  test("creates a loan through the default SDK API and hydrates canonical canister state", async () => {
     // given
     const BTC_MINTER_DEPOSIT_FEE_SATS = 2_000n;
     const CKBTC_LEDGER_FEE_SATS = 10n;
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          loan: {
-            loanId: LOAN_ID.toString(),
-            ref: publicIdFromInt(LOAN_ID),
-            profileId: PROFILE_ID,
-            ltvMaxBps: "6800",
-            depositWindowSeconds: "3600",
-            collateral: {
-              poolId: BTC_POOL_ID,
-              asset: "BTC",
-              amountHint: "10000000",
-            },
-            borrow: {
-              poolId: USDT_POOL_ID,
-              asset: "USDT",
-              amount: "5726000000",
-              destination: {
-                External: "0x2222222222222222222222222222222222222222",
+    const EXPIRY_TIMESTAMP_SECONDS = 1_775_235_600n;
+    const getLoan = vi.fn().mockResolvedValue({
+      Ok: createInstantLoan({ expires_at: [EXPIRY_TIMESTAMP_SECONDS] }),
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (_input, init) => {
+        if (init?.method === "POST") {
+          return new Response(
+            JSON.stringify({
+              success: true,
+              loan: {
+                loanId: LOAN_ID.toString(),
+                collateral: {
+                  amountHint: "10000000",
+                },
               },
-            },
-            refundDestination: { External: VALID_BTC_REFUND_ADDRESS },
-          },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } }
-      )
-    );
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          );
+        }
 
-    const actorCreateSpy = vi
-      .spyOn(Actor, "createActor")
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+    vi.spyOn(Actor, "createActor")
       .mockReturnValueOnce({
         list_pools: vi
           .fn()
@@ -4711,6 +4709,7 @@ describe("InstantLoansModule", () => {
       .mockReturnValueOnce({
         get_prices: vi.fn().mockResolvedValue(prices()),
       } as never)
+      .mockReturnValueOnce({ get_loan: getLoan } as never)
       .mockReturnValueOnce({
         list_pools: vi.fn().mockResolvedValue([createBtcPoolRecord()]),
       } as never)
@@ -4786,10 +4785,8 @@ describe("InstantLoansModule", () => {
         method: "POST",
       })
     );
-    expect(actorCreateSpy).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ canisterId: "kzrva-ziaaa-aaaar-qamyq-cai" })
-    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(getLoan).toHaveBeenCalledWith(LOAN_ID);
     expect(loan.loanId).toBe(LOAN_ID);
     expect(loan.status).toBe("awaiting_deposit");
     expect(loan.collateral.amount).toBe(10_000_000n);
@@ -4813,6 +4810,8 @@ describe("InstantLoansModule", () => {
       inflowFeeAmount: 2_500n,
       asset: "BTC",
       chain: "BTC",
+      detectedTimestamp: null,
+      expiryTimestamp: EXPIRY_TIMESTAMP_SECONDS,
       target: expect.objectContaining({
         address: "bc1qinstantdeposit",
       }),
@@ -5153,7 +5152,9 @@ describe("InstantLoansModule", () => {
     );
   });
 
-  function createInstantLoan(overrides: Record<string, unknown> = {}) {
+  function createInstantLoan(
+    overrides: Partial<InstantLoanCanisterRecord> = {}
+  ) {
     return {
       id: LOAN_ID,
       authorisation: {

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4226,12 +4226,10 @@ describe("InstantLoansModule", () => {
     // given
     const DEPOSIT_DETECTED_TIMESTAMP = 1_775_232_000n;
     const EXPIRY_TIMESTAMP = 1_775_235_600n;
-    const DEPOSIT_DETECTED_AT_NS = DEPOSIT_DETECTED_TIMESTAMP * 1_000_000_000n;
-    const EXPIRES_AT_NS = EXPIRY_TIMESTAMP * 1_000_000_000n;
     const getLoan = vi.fn().mockResolvedValue({
       Ok: createInstantLoan({
-        deposit_detected_ts: [DEPOSIT_DETECTED_AT_NS],
-        expires_at: [EXPIRES_AT_NS],
+        deposit_detected_ts: [DEPOSIT_DETECTED_TIMESTAMP],
+        expires_at: [EXPIRY_TIMESTAMP],
       }),
     });
     const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -4363,6 +4363,70 @@ describe("InstantLoansModule", () => {
     });
   });
 
+  test("should derive initial deposit expiry from detection timestamp when canister expiry is absent", async () => {
+    // given
+    const DEPOSIT_DETECTED_TIMESTAMP_SECONDS = 1_780_920_469n;
+    const DEPOSIT_WINDOW_SECONDS = 3_600n;
+    const EXPECTED_EXPIRY_TIMESTAMP_SECONDS =
+      DEPOSIT_DETECTED_TIMESTAMP_SECONDS + DEPOSIT_WINDOW_SECONDS;
+    const getLoan = vi.fn().mockResolvedValue({
+      Ok: createInstantLoan({
+        ltv_timer_s: DEPOSIT_WINDOW_SECONDS,
+        deposit_detected_ts: [DEPOSIT_DETECTED_TIMESTAMP_SECONDS],
+        expires_at: [],
+      }),
+    });
+    const getBtcAddress = vi.fn().mockResolvedValue("bc1qinstantdeposit");
+    const getDepositAddress = vi.fn().mockResolvedValue({
+      Ok: "0x1111111111111111111111111111111111111111",
+    });
+    const getPoolRate = vi
+      .fn()
+      .mockResolvedValue([[10_000_000_000_000_000_000_000_000n, 0n, 0n]]);
+    const getDepositFee = vi.fn().mockResolvedValue(2_000n);
+    const icrc1Fee = vi.fn().mockResolvedValue(10n);
+    mockInstantLoanLookupFetch({
+      collateralAmountHint: "10000000",
+    });
+
+    vi.spyOn(Actor, "createActor")
+      .mockReturnValueOnce({ get_loan: getLoan } as never)
+      .mockReturnValueOnce({
+        list_pools: vi.fn().mockResolvedValue([createBtcPoolRecord()]),
+      } as never)
+      .mockReturnValueOnce({
+        list_pools: vi.fn().mockResolvedValue([createUsdtPoolRecord()]),
+      } as never)
+      .mockReturnValueOnce({
+        get_position: vi.fn().mockResolvedValue([]),
+      } as never)
+      .mockReturnValueOnce({
+        get_position: vi.fn().mockResolvedValue([]),
+      } as never)
+      .mockReturnValueOnce({ get_pool_rate: getPoolRate } as never)
+      .mockReturnValueOnce({ get_btc_address: getBtcAddress } as never)
+      .mockReturnValueOnce({ get_deposit_address: getDepositAddress } as never)
+      .mockReturnValueOnce({ get_deposit_fee: getDepositFee } as never)
+      .mockReturnValueOnce({ icrc1_fee: icrc1Fee } as never);
+    const client = new LiquidiumClient({
+      apiBaseUrl: "https://app.liquidium.fi/api/sdk",
+      canisterIds: { instantLoans: "kzrva-ziaaa-aaaar-qamyq-cai" },
+    });
+
+    // when
+    const loan = await client.instantLoans.get({
+      ref: publicIdFromInt(LOAN_ID),
+    });
+
+    // then
+    expect(loan.initialDeposit.detectedTimestamp).toBe(
+      DEPOSIT_DETECTED_TIMESTAMP_SECONDS
+    );
+    expect(loan.initialDeposit.expiryTimestamp).toBe(
+      EXPECTED_EXPIRY_TIMESTAMP_SECONDS
+    );
+  });
+
   test("includes btc inflow fee in the instant loan repayment quote", async () => {
     // given
     const getLoan = vi.fn().mockResolvedValue({

--- a/packages/client/src/modules/accounts/types.ts
+++ b/packages/client/src/modules/accounts/types.ts
@@ -27,7 +27,7 @@ export interface CreateProfileParams {
 
 /** Data embedded in a prepared profile-creation action. */
 export interface CreateAccountData {
-  /** Expiry timestamp, in protocol nanoseconds, included in the signed message. */
+  /** Unix expiry timestamp in seconds, included in the signed message. */
   expiryTimestamp: bigint;
 }
 

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -45,6 +45,7 @@ import type {
   InstantLoanEvent,
   InstantLoanEventType,
   InstantLoanGetRequest,
+  InstantLoanInitialDeposit,
   InstantLoanLeg,
   InstantLoanListEventsRequest,
   InstantLoanStatus as InstantLoanStatusValue,
@@ -116,51 +117,13 @@ interface InstantLoanCreateAccountWire {
   External: string;
 }
 
-interface InstantLoanNativeAccountVariantWire {
-  Native: string;
-}
-
-type InstantLoanAccountVariantWire =
-  | InstantLoanCreateAccountWire
-  | InstantLoanNativeAccountVariantWire;
-
-interface InstantLoanExternalAccountObjectWire {
-  address: string;
-  type: "External";
-}
-
-interface InstantLoanNativeAccountObjectWire {
-  principal: string;
-  type: "Native";
-}
-
-type InstantLoanAccountWire =
-  | InstantLoanExternalAccountObjectWire
-  | InstantLoanNativeAccountObjectWire
-  | InstantLoanAccountVariantWire;
-
-interface InstantLoanCollateralWire {
-  poolId: string;
-  asset: string;
+interface InstantLoanWireCollateral {
   amountHint: string;
-}
-
-interface InstantLoanBorrowWire {
-  poolId: string;
-  asset: string;
-  amount: string;
-  destination: InstantLoanAccountWire;
 }
 
 interface InstantLoanWire {
   loanId: string;
-  ref?: string;
-  profileId: string;
-  ltvMaxBps: string;
-  depositWindowSeconds: string;
-  collateral: InstantLoanCollateralWire;
-  borrow: InstantLoanBorrowWire;
-  refundDestination: InstantLoanAccountWire;
+  collateral: InstantLoanWireCollateral;
 }
 
 interface InstantLoanHydrationInput {
@@ -185,16 +148,8 @@ interface InstantLoanInitialDepositQuoteInput {
   decimals: bigint;
   asset: string;
   target: SupplyTarget;
-}
-
-interface InstantLoanInitialDepositQuote {
-  amount: bigint;
-  decimals: bigint;
-  collateralAmount: bigint;
-  inflowFeeAmount: bigint;
-  asset: string;
-  chain: string;
-  target: SupplyTarget;
+  detectedTimestamp: bigint | null;
+  expiryTimestamp: bigint | null;
 }
 
 interface RepaymentInflowFeeEstimate {
@@ -274,7 +229,14 @@ export class InstantLoansModule {
       refundDestination,
     });
 
-    return await this.mapLoanWire(response.loan);
+    const loanId = parseBigintWire(response.loan.loanId, "loan ID");
+    const collateralAmount = parseBigintWire(
+      response.loan.collateral.amountHint,
+      "collateral amount"
+    );
+    const record = await this.getLoanRecord(loanId);
+
+    return await this.mapLoanRecord(record, collateralAmount);
   }
 
   /**
@@ -290,25 +252,10 @@ export class InstantLoansModule {
     const loanId =
       "loanId" in request ? request.loanId : decodeRef(request.ref);
 
-    try {
-      const result = await createInstantLoansActor(
-        this.canisterContext
-      ).get_loan(loanId);
+    const record = await this.getLoanRecord(loanId);
+    const collateralAmount = await this.getCollateralAmountHint(loanId);
 
-      if ("Err" in result) {
-        throw mapInstantLoansErrorToLiquidiumError(result.Err);
-      }
-
-      const collateralAmount = await this.getCollateralAmountHint(loanId);
-
-      return await this.mapLoanRecord(result.Ok, collateralAmount);
-    } catch (error) {
-      if (error instanceof LiquidiumError) {
-        throw error;
-      }
-
-      throw mapCanisterCallErrorToLiquidiumError("get_loan", error);
-    }
+    return await this.mapLoanRecord(record, collateralAmount);
   }
 
   /**
@@ -447,6 +394,28 @@ export class InstantLoansModule {
     return (response.candidates ?? response.loans ?? []).map(mapCandidateWire);
   }
 
+  private async getLoanRecord(
+    loanId: bigint
+  ): Promise<InstantLoanCanisterRecord> {
+    try {
+      const result = await createInstantLoansActor(
+        this.canisterContext
+      ).get_loan(loanId);
+
+      if ("Err" in result) {
+        throw mapInstantLoansErrorToLiquidiumError(result.Err);
+      }
+
+      return result.Ok;
+    } catch (error) {
+      if (error instanceof LiquidiumError) {
+        throw error;
+      }
+
+      throw mapCanisterCallErrorToLiquidiumError("get_loan", error);
+    }
+  }
+
   private async mapLoanRecord(
     record: InstantLoanCanisterRecord,
     collateralAmount: bigint
@@ -476,33 +445,6 @@ export class InstantLoansModule {
     );
 
     return parseBigintWire(response.collateralAmountHint, "collateral amount");
-  }
-
-  private async mapLoanWire(loan: InstantLoanWire): Promise<InstantLoan> {
-    const loanId = parseBigintWire(loan.loanId, "loan ID");
-
-    return await this.hydrateLoan({
-      loanId,
-      profileId: loan.profileId,
-      ltvMaxBps: parseBigintWire(loan.ltvMaxBps, "max LTV"),
-      depositWindowSeconds: parseBigintWire(
-        loan.depositWindowSeconds,
-        "deposit window"
-      ),
-      collateralPoolId: loan.collateral.poolId,
-      collateralAmount: parseBigintWire(
-        loan.collateral.amountHint,
-        "collateral amount"
-      ),
-      borrowPoolId: loan.borrow.poolId,
-      collateralAsset: loan.collateral.asset,
-      borrowAsset: loan.borrow.asset,
-      borrowAmount: parseBigintWire(loan.borrow.amount, "borrow amount"),
-      borrowDestination: accountFromWire(loan.borrow.destination),
-      refundDestination: accountFromWire(loan.refundDestination),
-      depositDetectedTimestamp: null,
-      expiryTimestamp: null,
-    });
   }
 
   private async hydrateLoan(
@@ -571,11 +513,13 @@ export class InstantLoansModule {
       totalDebtAmount,
     });
 
-    const initialDepositQuote = await this.createInitialDepositQuote({
+    const initialDeposit = await this.createInitialDepositQuote({
       collateralAmount,
       decimals: collateralDecimals,
       asset: collateralAsset,
       target: depositTarget,
+      detectedTimestamp: input.depositDetectedTimestamp,
+      expiryTimestamp: input.expiryTimestamp,
     });
 
     const repayment = {
@@ -616,11 +560,7 @@ export class InstantLoansModule {
         destination: input.borrowDestination,
       },
       refundDestination: input.refundDestination,
-      initialDeposit: {
-        ...initialDepositQuote,
-        detectedTimestamp: input.depositDetectedTimestamp,
-        expiryTimestamp: input.expiryTimestamp,
-      },
+      initialDeposit,
       repayment,
       position: {
         collateralAmount: currentCollateralAmount,
@@ -636,7 +576,7 @@ export class InstantLoansModule {
 
   private async createInitialDepositQuote(
     input: InstantLoanInitialDepositQuoteInput
-  ): Promise<InstantLoanInitialDepositQuote> {
+  ): Promise<InstantLoanInitialDeposit> {
     const inflowFee = await this.lending.estimateInflowFee({
       asset: input.asset as Asset,
       chain: input.target.chain as Chain,
@@ -650,6 +590,8 @@ export class InstantLoansModule {
       asset: input.asset,
       chain: input.target.chain,
       target: input.target,
+      detectedTimestamp: input.detectedTimestamp,
+      expiryTimestamp: input.expiryTimestamp,
     };
   }
 
@@ -841,22 +783,6 @@ function accountFromCanister(
   }
 
   return { type: "External", address: account.External };
-}
-
-function accountFromWire(account: InstantLoanAccountWire): InstantLoanAccount {
-  if ("Native" in account) {
-    return { type: "Native", principal: account.Native };
-  }
-
-  if ("External" in account) {
-    return { type: "External", address: account.External };
-  }
-
-  if (account.type === "Native") {
-    return { type: "Native", principal: account.principal };
-  }
-
-  return { type: "External", address: account.address };
 }
 
 function mapInstantLoanEvent(event: HeadlessLoanEvent): InstantLoanEvent {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -45,7 +45,6 @@ import type {
   InstantLoanEvent,
   InstantLoanEventType,
   InstantLoanGetRequest,
-  InstantLoanInitialDeposit,
   InstantLoanLeg,
   InstantLoanListEventsRequest,
   InstantLoanStatus as InstantLoanStatusValue,
@@ -58,7 +57,6 @@ const RATE_SCALE = 10n ** 27n;
 const SECONDS_PER_YEAR = 31_536_000n;
 const ETH_STABLECOIN_INFLOW_FEE_FALLBACK = 1_500_000n;
 const INSTANT_LOAN_MIN_SLIPPAGE_BUFFER_BPS = 200n;
-const NANOSECONDS_PER_SECOND = 1_000_000_000n;
 
 interface InstantLoanLtvPolicy {
   ltvBps: bigint;
@@ -160,10 +158,6 @@ interface InstantLoanWire {
   profileId: string;
   ltvMaxBps: string;
   depositWindowSeconds: string;
-  depositDetectedAt?: string | null;
-  deposit_detected_ts?: string | null;
-  expiresAt?: string | null;
-  expires_at?: string | null;
   collateral: InstantLoanCollateralWire;
   borrow: InstantLoanBorrowWire;
   refundDestination: InstantLoanAccountWire;
@@ -191,8 +185,16 @@ interface InstantLoanInitialDepositQuoteInput {
   decimals: bigint;
   asset: string;
   target: SupplyTarget;
-  detectedTimestamp: bigint | null;
-  expiryTimestamp: bigint | null;
+}
+
+interface InstantLoanInitialDepositQuote {
+  amount: bigint;
+  decimals: bigint;
+  collateralAmount: bigint;
+  inflowFeeAmount: bigint;
+  asset: string;
+  chain: string;
+  target: SupplyTarget;
 }
 
 interface RepaymentInflowFeeEstimate {
@@ -462,10 +464,8 @@ export class InstantLoansModule {
       borrowAmount: record.borrow_amount,
       borrowDestination: accountFromCanister(record.borrow_destination),
       refundDestination: accountFromCanister(record.refund_destination),
-      depositDetectedTimestamp: unixSecondsFromProtocolTimestampNs(
-        record.deposit_detected_ts[0]
-      ),
-      expiryTimestamp: unixSecondsFromProtocolTimestampNs(record.expires_at[0]),
+      depositDetectedTimestamp: record.deposit_detected_ts[0] ?? null,
+      expiryTimestamp: record.expires_at[0] ?? null,
     });
   }
 
@@ -500,14 +500,8 @@ export class InstantLoansModule {
       borrowAmount: parseBigintWire(loan.borrow.amount, "borrow amount"),
       borrowDestination: accountFromWire(loan.borrow.destination),
       refundDestination: accountFromWire(loan.refundDestination),
-      depositDetectedTimestamp: parseNullableUnixSecondsWire(
-        loan.depositDetectedAt ?? loan.deposit_detected_ts,
-        "deposit detected timestamp"
-      ),
-      expiryTimestamp: parseNullableUnixSecondsWire(
-        loan.expiresAt ?? loan.expires_at,
-        "expiry timestamp"
-      ),
+      depositDetectedTimestamp: null,
+      expiryTimestamp: null,
     });
   }
 
@@ -577,13 +571,11 @@ export class InstantLoansModule {
       totalDebtAmount,
     });
 
-    const initialDeposit = await this.createInitialDepositQuote({
+    const initialDepositQuote = await this.createInitialDepositQuote({
       collateralAmount,
       decimals: collateralDecimals,
       asset: collateralAsset,
       target: depositTarget,
-      detectedTimestamp: input.depositDetectedTimestamp,
-      expiryTimestamp: input.expiryTimestamp,
     });
 
     const repayment = {
@@ -624,7 +616,11 @@ export class InstantLoansModule {
         destination: input.borrowDestination,
       },
       refundDestination: input.refundDestination,
-      initialDeposit,
+      initialDeposit: {
+        ...initialDepositQuote,
+        detectedTimestamp: input.depositDetectedTimestamp,
+        expiryTimestamp: input.expiryTimestamp,
+      },
       repayment,
       position: {
         collateralAmount: currentCollateralAmount,
@@ -640,7 +636,7 @@ export class InstantLoansModule {
 
   private async createInitialDepositQuote(
     input: InstantLoanInitialDepositQuoteInput
-  ): Promise<InstantLoanInitialDeposit> {
+  ): Promise<InstantLoanInitialDepositQuote> {
     const inflowFee = await this.lending.estimateInflowFee({
       asset: input.asset as Asset,
       chain: input.target.chain as Chain,
@@ -654,8 +650,6 @@ export class InstantLoansModule {
       asset: input.asset,
       chain: input.target.chain,
       target: input.target,
-      detectedTimestamp: input.detectedTimestamp,
-      expiryTimestamp: input.expiryTimestamp,
     };
   }
 
@@ -1048,39 +1042,6 @@ function parseBigintWire(value: string | undefined, label: string): bigint {
   }
 
   return BigInt(value);
-}
-
-function parseNullableUnixSecondsWire(
-  value: string | null | undefined,
-  label: string
-): bigint | null {
-  if (value == null) {
-    return null;
-  }
-
-  if (/^\d+$/.test(value)) {
-    return unixSecondsFromProtocolTimestampNs(BigInt(value));
-  }
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    throw new LiquidiumError(
-      LiquidiumErrorCode.VALIDATION_ERROR,
-      `Invalid instant loan ${label}`
-    );
-  }
-
-  return BigInt(Math.floor(date.getTime() / 1_000));
-}
-
-function unixSecondsFromProtocolTimestampNs(
-  timestampNs: bigint | undefined
-): bigint | null {
-  if (timestampNs === undefined) {
-    return null;
-  }
-
-  return timestampNs / NANOSECONDS_PER_SECOND;
 }
 
 function requiredString(value: string | undefined, label: string): string {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -58,6 +58,7 @@ const RATE_SCALE = 10n ** 27n;
 const SECONDS_PER_YEAR = 31_536_000n;
 const ETH_STABLECOIN_INFLOW_FEE_FALLBACK = 1_500_000n;
 const INSTANT_LOAN_MIN_SLIPPAGE_BUFFER_BPS = 200n;
+const NANOSECONDS_PER_SECOND = 1_000_000_000n;
 
 interface InstantLoanLtvPolicy {
   ltvBps: bigint;
@@ -159,6 +160,10 @@ interface InstantLoanWire {
   profileId: string;
   ltvMaxBps: string;
   depositWindowSeconds: string;
+  depositDetectedAt?: string | null;
+  deposit_detected_ts?: string | null;
+  expiresAt?: string | null;
+  expires_at?: string | null;
   collateral: InstantLoanCollateralWire;
   borrow: InstantLoanBorrowWire;
   refundDestination: InstantLoanAccountWire;
@@ -177,6 +182,8 @@ interface InstantLoanHydrationInput {
   borrowAmount: bigint;
   borrowDestination: InstantLoanAccount;
   refundDestination: InstantLoanAccount;
+  depositDetectedTimestamp: bigint | null;
+  expiryTimestamp: bigint | null;
 }
 
 interface InstantLoanInitialDepositQuoteInput {
@@ -184,6 +191,8 @@ interface InstantLoanInitialDepositQuoteInput {
   decimals: bigint;
   asset: string;
   target: SupplyTarget;
+  detectedTimestamp: bigint | null;
+  expiryTimestamp: bigint | null;
 }
 
 interface RepaymentInflowFeeEstimate {
@@ -453,6 +462,10 @@ export class InstantLoansModule {
       borrowAmount: record.borrow_amount,
       borrowDestination: accountFromCanister(record.borrow_destination),
       refundDestination: accountFromCanister(record.refund_destination),
+      depositDetectedTimestamp: unixSecondsFromProtocolTimestampNs(
+        record.deposit_detected_ts[0]
+      ),
+      expiryTimestamp: unixSecondsFromProtocolTimestampNs(record.expires_at[0]),
     });
   }
 
@@ -487,6 +500,14 @@ export class InstantLoansModule {
       borrowAmount: parseBigintWire(loan.borrow.amount, "borrow amount"),
       borrowDestination: accountFromWire(loan.borrow.destination),
       refundDestination: accountFromWire(loan.refundDestination),
+      depositDetectedTimestamp: parseNullableUnixSecondsWire(
+        loan.depositDetectedAt ?? loan.deposit_detected_ts,
+        "deposit detected timestamp"
+      ),
+      expiryTimestamp: parseNullableUnixSecondsWire(
+        loan.expiresAt ?? loan.expires_at,
+        "expiry timestamp"
+      ),
     });
   }
 
@@ -561,6 +582,8 @@ export class InstantLoansModule {
       decimals: collateralDecimals,
       asset: collateralAsset,
       target: depositTarget,
+      detectedTimestamp: input.depositDetectedTimestamp,
+      expiryTimestamp: input.expiryTimestamp,
     });
 
     const repayment = {
@@ -631,6 +654,8 @@ export class InstantLoansModule {
       asset: input.asset,
       chain: input.target.chain,
       target: input.target,
+      detectedTimestamp: input.detectedTimestamp,
+      expiryTimestamp: input.expiryTimestamp,
     };
   }
 
@@ -1023,6 +1048,39 @@ function parseBigintWire(value: string | undefined, label: string): bigint {
   }
 
   return BigInt(value);
+}
+
+function parseNullableUnixSecondsWire(
+  value: string | null | undefined,
+  label: string
+): bigint | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (/^\d+$/.test(value)) {
+    return unixSecondsFromProtocolTimestampNs(BigInt(value));
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new LiquidiumError(
+      LiquidiumErrorCode.VALIDATION_ERROR,
+      `Invalid instant loan ${label}`
+    );
+  }
+
+  return BigInt(Math.floor(date.getTime() / 1_000));
+}
+
+function unixSecondsFromProtocolTimestampNs(
+  timestampNs: bigint | undefined
+): bigint | null {
+  if (timestampNs === undefined) {
+    return null;
+  }
+
+  return timestampNs / NANOSECONDS_PER_SECOND;
 }
 
 function requiredString(value: string | undefined, label: string): string {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -434,7 +434,12 @@ export class InstantLoansModule {
       borrowDestination: accountFromCanister(record.borrow_destination),
       refundDestination: accountFromCanister(record.refund_destination),
       depositDetectedTimestamp: record.deposit_detected_ts[0] ?? null,
-      expiryTimestamp: record.expires_at[0] ?? null,
+      expiryTimestamp:
+        record.expires_at[0] ??
+        deriveDepositExpiryTimestamp({
+          depositDetectedTimestamp: record.deposit_detected_ts[0] ?? null,
+          depositWindowSeconds: record.ltv_timer_s,
+        }),
     });
   }
 
@@ -722,6 +727,17 @@ function deriveInstantLoanStatus(
   }
 
   return InstantLoanStatus.awaitingDeposit;
+}
+
+function deriveDepositExpiryTimestamp(input: {
+  depositDetectedTimestamp: bigint | null;
+  depositWindowSeconds: bigint;
+}): bigint | null {
+  if (input.depositDetectedTimestamp === null) {
+    return null;
+  }
+
+  return input.depositDetectedTimestamp + input.depositWindowSeconds;
 }
 
 function validateCreateRequest(request: CreateInstantLoanRequest): void {

--- a/packages/client/src/modules/instant-loans/instant-loans.ts
+++ b/packages/client/src/modules/instant-loans/instant-loans.ts
@@ -162,6 +162,11 @@ interface DeriveInstantLoanStatusInput {
   totalDebtAmount: bigint;
 }
 
+interface DeriveDepositExpiryTimestampInput {
+  depositDetectedTimestamp: bigint | null;
+  depositWindowSeconds: bigint;
+}
+
 interface LtvCalculationErrorDetails {
   code: QuoteValidationErrorCode;
   message: string;
@@ -729,10 +734,9 @@ function deriveInstantLoanStatus(
   return InstantLoanStatus.awaitingDeposit;
 }
 
-function deriveDepositExpiryTimestamp(input: {
-  depositDetectedTimestamp: bigint | null;
-  depositWindowSeconds: bigint;
-}): bigint | null {
+function deriveDepositExpiryTimestamp(
+  input: DeriveDepositExpiryTimestampInput
+): bigint | null {
   if (input.depositDetectedTimestamp === null) {
     return null;
   }

--- a/packages/client/src/modules/instant-loans/types.ts
+++ b/packages/client/src/modules/instant-loans/types.ts
@@ -175,6 +175,7 @@ export interface InstantLoanAuthorization {
 export interface InstantLoanWarmedProfile {
   id: bigint;
   authorization: InstantLoanAuthorization;
+  /** Unix creation timestamp in seconds. */
   createdAt: bigint;
   profileId: string;
 }
@@ -183,6 +184,7 @@ export interface InstantLoanWarmedProfile {
 export interface InstantLoanEvent {
   id: bigint;
   schemaVersion: number;
+  /** Unix event timestamp in seconds. */
   timestamp: bigint;
   eventType: InstantLoanEventType;
 }
@@ -259,6 +261,7 @@ export interface InstantLoanRepayCompleteEventType {
 export interface InstantLoanDepositTimerStartedEventType {
   type: "DepositTimerStarted";
   loanId: bigint;
+  /** Unix timestamp in seconds when the deposit timer started. */
   timestamp: bigint;
 }
 

--- a/packages/client/src/modules/instant-loans/types.ts
+++ b/packages/client/src/modules/instant-loans/types.ts
@@ -318,7 +318,7 @@ export interface InstantLoanInitialDeposit {
   target: SupplyTarget;
   /** Unix timestamp in seconds when the collateral deposit was detected, or null before detection. */
   detectedTimestamp: bigint | null;
-  /** Unix timestamp in seconds when the collateral deposit window expires, or null when unavailable. */
+  /** Unix timestamp in seconds when the collateral deposit window expires, or null before detection when unavailable. */
   expiryTimestamp: bigint | null;
 }
 

--- a/packages/client/src/modules/instant-loans/types.ts
+++ b/packages/client/src/modules/instant-loans/types.ts
@@ -313,6 +313,10 @@ export interface InstantLoanInitialDeposit {
   chain: MarketChain;
   /** Address or ICRC account where the collateral should be sent. */
   target: SupplyTarget;
+  /** Unix timestamp in seconds when the collateral deposit was detected, or null before detection. */
+  detectedTimestamp: bigint | null;
+  /** Unix timestamp in seconds when the collateral deposit window expires, or null when unavailable. */
+  expiryTimestamp: bigint | null;
 }
 
 /** Current lending position backing the instant loan. */

--- a/packages/client/src/modules/lending/types.ts
+++ b/packages/client/src/modules/lending/types.ts
@@ -115,7 +115,7 @@ export interface CreateBorrowRequest {
 
 /** Prepared borrow request data embedded in the signable action. */
 export interface CreateBorrowData extends CreateBorrowRequest {
-  /** Expiry timestamp, in protocol nanoseconds, included in the signed message. */
+  /** Unix expiry timestamp in seconds, included in the signed message. */
   expiryTimestamp: bigint;
 }
 
@@ -148,7 +148,7 @@ export interface CreateWithdrawRequest {
 
 /** Prepared withdraw request data embedded in the signable action. */
 export interface CreateWithdrawData extends CreateWithdrawRequest {
-  /** Expiry timestamp, in protocol nanoseconds, included in the signed message. */
+  /** Unix expiry timestamp in seconds, included in the signed message. */
   expiryTimestamp: bigint;
 }
 

--- a/packages/client/src/modules/market/types.ts
+++ b/packages/client/src/modules/market/types.ts
@@ -54,7 +54,7 @@ export interface Pool {
   borrowIndex: bigint;
   /** Whether borrowing the same asset as collateral is allowed. */
   sameAssetBorrowing: boolean;
-  /** Last pool update timestamp when available. */
+  /** Unix timestamp in seconds of the last pool update when available. */
   lastUpdated?: bigint;
 }
 

--- a/packages/client/src/modules/positions/types.ts
+++ b/packages/client/src/modules/positions/types.ts
@@ -19,7 +19,7 @@ export interface Position {
   earnedInterest: bigint;
   /** Accrued borrow interest in base units. */
   debtInterest: bigint;
-  /** Protocol timestamp of the last position update. */
+  /** Unix timestamp in seconds of the last position update. */
   lastUpdate: bigint;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instant loan responses now include two new initial-deposit timestamp fields: detectedTimestamp and expiryTimestamp (Unix seconds, nullable).

* **Documentation**
  * README and client docs updated to clarify timestamp semantics; example output now formats deposit detected/expiry values.

* **Tests**
  * Tests extended to validate detection and expiry timestamp behavior, including fallback derivation when expiry is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->