### PR TITLE
feat(client): add full withdraw amount helper

### DIFF
--- a/.changeset/full-withdraw-amount.md
+++ b/.changeset/full-withdraw-amount.md
@@ -1,0 +1,5 @@
+---
+"@liquidium/client": minor
+---
+
+Expose a helper for reading a position's full withdraw amount.

--- a/.changeset/full-withdraw-amount.md
+++ b/.changeset/full-withdraw-amount.md
@@ -2,4 +2,5 @@
 "@liquidium/client": minor
 ---
 
-Expose a helper for reading a position's full withdraw amount.
+Expose a helper for reading a position's full withdraw amount, and avoid
+double-counting supply interest in reserve USD valuations.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Liquidium supports two borrowing and lending integration paths:
 | Path | Use when | Main SDK calls |
 | --- | --- | --- |
 | Recommended: accountless instant loans | You want a short checkout-style flow where users borrow against collateral without creating a Liquidium profile first | `client.instantLoans.create(...)`, `client.instantLoans.get(...)`, `client.activities.list(...)` |
-| Account-based profile flows | You want users to keep a Liquidium profile, manage positions across sessions, supply funds, borrow, withdraw, or use ETH contract-interaction deposits | `client.accounts.createProfile(...)`, `client.lending.supply(...)`, `client.lending.borrow(...)`, `client.lending.withdraw(...)`, `client.positions.list(...)` |
+| Account-based profile flows | You want users to keep a Liquidium profile, manage positions across sessions, supply funds, borrow, withdraw, or use ETH contract-interaction deposits | `client.accounts.createProfile(...)`, `client.lending.supply(...)`, `client.lending.borrow(...)`, `client.lending.withdraw(...)`, `client.positions.listPositions(...)` |
 
 Use accountless instant loans for new borrow flows unless you need profile-level position management. Use account-based flows when your app owns the full lending dashboard experience.
 
@@ -215,6 +215,10 @@ The SDK enforces product minimums before borrow creation:
 | USDT | `1_000_000n` base units |
 
 Use `getMinimumBorrowAmount(asset)` to display the same minimum that `client.quote.calculateLtv(...)`, `client.quote.getQuote(...)`, `client.instantLoans.create(...)`, and `client.lending.prepareBorrow(...)` enforce.
+
+### Profile full withdraw amounts
+
+For profile-based withdraw flows, call `client.positions.getFullWithdrawAmount(profileId, poolId)` before building the withdraw request. The helper returns `{ amount, decimals }`: pass `amount` to `client.lending.withdraw(...)` or `client.lending.prepareWithdraw(...)`, and use `decimals` for display formatting. Do not add `earnedInterest`; the returned amount already uses the current supplied balance.
 
 ## Response Fields
 

--- a/docs/api-reference/generated/README.md
+++ b/docs/api-reference/generated/README.md
@@ -55,6 +55,7 @@
 - [ExternalAccount](interfaces/ExternalAccount.md)
 - [ExternalOutflowReceiver](interfaces/ExternalOutflowReceiver.md)
 - [FindPoolQuery](interfaces/FindPoolQuery.md)
+- [FullWithdrawAmount](interfaces/FullWithdrawAmount.md)
 - [GetActivityStatusByProfileRequest](interfaces/GetActivityStatusByProfileRequest.md)
 - [GetActivityStatusByShortRefRequest](interfaces/GetActivityStatusByShortRefRequest.md)
 - [GetDepositAddressRequest](interfaces/GetDepositAddressRequest.md)

--- a/docs/api-reference/generated/classes/InstantLoansModule.md
+++ b/docs/api-reference/generated/classes/InstantLoansModule.md
@@ -6,7 +6,7 @@
 
 # Class: InstantLoansModule
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:202](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L202)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:200](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L200)
 
 Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
@@ -16,7 +16,7 @@ Accountless instant-loan creation, lookup, recovery, and canister query helpers.
 
 > **new InstantLoansModule**(`canisterContext`, `apiClient`, `lending`, `positions`): `InstantLoansModule`
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:203](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L203)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:201](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L201)
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:203](htt
 
 > **countWarmedProfiles**(): `Promise`\<`bigint`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:398](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L398)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:396](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L396)
 
 Returns the current size of the warmed-profile pool via direct query.
 
@@ -62,7 +62,7 @@ Number of warmed profiles available on the canister.
 
 > **create**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:227](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L227)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:225](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L225)
 
 Creates a profileless instant loan and returns canonical canister state plus
 generated initial-deposit and repayment quote targets.
@@ -97,7 +97,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **find**(`query`): `Promise`\<[`InstantLoanFindResult`](../interfaces/InstantLoanFindResult.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:305](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L305)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:303](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L303)
 
 Finds instant loans by short reference, numeric loan id string, address, or transaction id.
 
@@ -124,7 +124,7 @@ Matching loan ids and references from the search index.
 
 > **get**(`request`): `Promise`\<[`InstantLoan`](../interfaces/InstantLoan.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:286](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L286)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:284](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L284)
 
 Resolves canonical canister state by loan id or short reference.
 
@@ -151,7 +151,7 @@ Hydrated loan state plus generated initial-deposit and repayment quote targets.
 
 > **getConfig**(): `Promise`\<[`InstantLoanConfig`](../interfaces/InstantLoanConfig.md)\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:324](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L324)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:322](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L322)
 
 Returns the active instant-loans canister config via direct query.
 
@@ -167,7 +167,7 @@ Active canister configuration.
 
 > **getEvent**(`eventId`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md) \| `null`\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:344](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L344)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:342](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L342)
 
 Returns a single canister event by id via direct query.
 
@@ -191,7 +191,7 @@ The event when found, otherwise `null`.
 
 > **listAccessList**(): `Promise`\<`string`[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:381](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L381)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:379](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L379)
 
 Returns principals authorized for protected update callbacks.
 
@@ -207,7 +207,7 @@ Principal text values on the canister access list.
 
 > **listEvents**(`request`): `Promise`\<[`InstantLoanEvent`](../interfaces/InstantLoanEvent.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:362](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L362)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:360](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L360)
 
 Returns a page of canister events via direct query.
 
@@ -231,7 +231,7 @@ Canister events in ascending id order.
 
 > **listWarmedProfiles**(): `Promise`\<[`InstantLoanWarmedProfile`](../interfaces/InstantLoanWarmedProfile.md)[]\>
 
-Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:416](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L416)
+Defined in: [packages/client/src/modules/instant-loans/instant-loans.ts:414](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/instant-loans/instant-loans.ts#L414)
 
 Returns warmed profiles currently available for future instant loans.
 

--- a/docs/api-reference/generated/classes/PositionsModule.md
+++ b/docs/api-reference/generated/classes/PositionsModule.md
@@ -6,7 +6,7 @@
 
 # Class: PositionsModule
 
-Defined in: [packages/client/src/modules/positions/positions.ts:26](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L26)
+Defined in: [packages/client/src/modules/positions/positions.ts:27](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L27)
 
 Profile position, health factor, and reserve valuation helpers.
 
@@ -16,7 +16,7 @@ Profile position, health factor, and reserve valuation helpers.
 
 > **new PositionsModule**(`canisterContext`, `market`): `PositionsModule`
 
-Defined in: [packages/client/src/modules/positions/positions.ts:27](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L27)
+Defined in: [packages/client/src/modules/positions/positions.ts:28](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L28)
 
 #### Parameters
 
@@ -38,15 +38,49 @@ Defined in: [packages/client/src/modules/positions/positions.ts:27](https://gith
 
 > `readonly` **market**: [`MarketModule`](MarketModule.md)
 
-Defined in: [packages/client/src/modules/positions/positions.ts:29](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L29)
+Defined in: [packages/client/src/modules/positions/positions.ts:30](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L30)
 
 ## Methods
+
+### getFullWithdrawAmount()
+
+> **getFullWithdrawAmount**(`profileId`, `poolId`): `Promise`\<[`FullWithdrawAmount`](../interfaces/FullWithdrawAmount.md)\>
+
+Defined in: [packages/client/src/modules/positions/positions.ts:269](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L269)
+
+Returns the current full withdraw amount for a position.
+
+`Position.deposited` already reflects the current supplied balance at the
+latest lending index; do not add `earnedInterest` to this amount.
+Pass `amount` to withdraw calls and use `decimals` for display formatting.
+
+#### Parameters
+
+##### profileId
+
+`string`
+
+The Liquidium profile principal text.
+
+##### poolId
+
+`string`
+
+The pool principal text.
+
+#### Returns
+
+`Promise`\<[`FullWithdrawAmount`](../interfaces/FullWithdrawAmount.md)\>
+
+Full withdraw amount in the supplied asset's base units.
+
+***
 
 ### getHealthFactor()
 
 > **getHealthFactor**(`profileId`): `Promise`\<[`HealthFactor`](../interfaces/HealthFactor.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:100](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L100)
+Defined in: [packages/client/src/modules/positions/positions.ts:101](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L101)
 
 Returns the current health factor for a profile.
 
@@ -70,7 +104,7 @@ The current health factor for the requested profile.
 
 > **getMaxRepayAmount**(`profileId`, `poolId`, `bufferBps?`): `Promise`\<[`MaxRepayAmount`](../interfaces/MaxRepayAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:237](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L237)
+Defined in: [packages/client/src/modules/positions/positions.ts:238](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L238)
 
 Returns the full repayment amount for a position, with a small buffer to
 account for interest that accrues between quote and submit.
@@ -107,7 +141,7 @@ Buffered repayment amount in the borrowed asset's base units.
 
 > **getPosition**(`profileId`, `poolId`): `Promise`\<[`Position`](../interfaces/Position.md) \| `null`\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:39](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L39)
+Defined in: [packages/client/src/modules/positions/positions.ts:40](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L40)
 
 Returns a single position for a profile and pool.
 
@@ -137,7 +171,7 @@ The position for the requested profile and pool, or `null` when no position exis
 
 > **getUserPositionSummary**(`profileId`): `Promise`\<[`UserPositionSummary`](../interfaces/UserPositionSummary.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:152](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L152)
+Defined in: [packages/client/src/modules/positions/positions.ts:153](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L153)
 
 Returns an aggregate summary of a profile's position.
 
@@ -166,7 +200,7 @@ Derived position summary for the requested profile.
 
 > **getUserReserves**(`profileId`): `Promise`\<[`UserReserve`](../interfaces/UserReserve.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:188](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L188)
+Defined in: [packages/client/src/modules/positions/positions.ts:189](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L189)
 
 Returns the per-reserve breakdown of a profile's supplies and borrows,
 joined with pool metadata, rates, and current USD prices.
@@ -193,7 +227,7 @@ Per-reserve position rows joined with pool metadata and USD values.
 
 > **getUserStats**(`profileId`): `Promise`\<[`UserStats`](../interfaces/UserStats.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:125](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L125)
+Defined in: [packages/client/src/modules/positions/positions.ts:126](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L126)
 
 Returns aggregate borrowing and collateral stats for a profile.
 
@@ -217,7 +251,7 @@ Aggregate debt, collateral, and borrowing power metrics for the requested profil
 
 > **listPositions**(`profileId`): `Promise`\<[`Position`](../interfaces/Position.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:69](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L69)
+Defined in: [packages/client/src/modules/positions/positions.ts:70](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L70)
 
 Lists all positions for a profile.
 

--- a/docs/api-reference/generated/interfaces/FullWithdrawAmount.md
+++ b/docs/api-reference/generated/interfaces/FullWithdrawAmount.md
@@ -1,0 +1,31 @@
+[**@liquidium/client**](../README.md)
+
+***
+
+[@liquidium/client](../README.md) / FullWithdrawAmount
+
+# Interface: FullWithdrawAmount
+
+Defined in: [packages/client/src/modules/positions/types.ts:107](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/types.ts#L107)
+
+Full withdraw amount for a position.
+
+## Properties
+
+### amount
+
+> **amount**: `bigint`
+
+Defined in: [packages/client/src/modules/positions/types.ts:109](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/types.ts#L109)
+
+Amount to withdraw in the supplied asset's base units.
+
+***
+
+### decimals
+
+> **decimals**: `bigint`
+
+Defined in: [packages/client/src/modules/positions/types.ts:111](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/types.ts#L111)
+
+Decimal scale for `amount`.

--- a/docs/api-reference/generated/interfaces/Position.md
+++ b/docs/api-reference/generated/interfaces/Position.md
@@ -58,7 +58,7 @@ Accrued borrow interest in base units.
 
 Defined in: [packages/client/src/modules/positions/types.ts:11](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/types.ts#L11)
 
-Supplied principal in base units.
+Current supplied amount in base units.
 
 ***
 

--- a/examples/sdk-method-query/README.md
+++ b/examples/sdk-method-query/README.md
@@ -41,6 +41,7 @@ history, quote, lending, and instant-loan methods:
 
 - `history.getPoolHistory`
 - `history.getPoolConfigHistory`
+- `positions.getFullWithdrawAmount`
 - `instantLoans.create`
 - `instantLoans.get({ ref })`
 - `instantLoans.get({ loanId })`

--- a/examples/sdk-method-query/src/SdkMethodQueryPage.tsx
+++ b/examples/sdk-method-query/src/SdkMethodQueryPage.tsx
@@ -224,6 +224,18 @@ const SDK_METHODS: MethodDefinition[] = [
     },
   },
   {
+    id: "positions.getFullWithdrawAmount",
+    label: "positions.getFullWithdrawAmount",
+    defaultArgs: '{\n  "profileId": "aaaaa-aa",\n  "poolId": "bbbbb-bb"\n}',
+    execute: async (client, input) => {
+      const args = expectObject(input);
+      return await client.positions.getFullWithdrawAmount(
+        expectNonEmptyString(args.profileId, "profileId"),
+        expectNonEmptyString(args.poolId, "poolId")
+      );
+    },
+  },
+  {
     id: "activities.list",
     label: "activities.list",
     defaultArgs: '{\n  "shortRef": "Y7R19F",\n  "filter": "all"\n}',

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -39,7 +39,7 @@ Liquidium supports two borrowing and lending integration paths:
 | Path | Use when | Main SDK calls |
 | --- | --- | --- |
 | Recommended: accountless instant loans | You want a short checkout-style flow where users borrow against collateral without creating a Liquidium profile first | `client.instantLoans.create(...)`, `client.instantLoans.get(...)`, `client.instantLoans.find(...)`, `client.activities.list(...)` |
-| Account-based profile flows | You want users to keep a Liquidium profile, manage positions across sessions, supply funds, borrow, withdraw, or use ETH contract-interaction deposits | `client.accounts.createProfile(...)`, `client.lending.supply(...)`, `client.lending.borrow(...)`, `client.lending.withdraw(...)`, `client.positions.list(...)` |
+| Account-based profile flows | You want users to keep a Liquidium profile, manage positions across sessions, supply funds, borrow, withdraw, or use ETH contract-interaction deposits | `client.accounts.createProfile(...)`, `client.lending.supply(...)`, `client.lending.borrow(...)`, `client.lending.withdraw(...)`, `client.positions.listPositions(...)` |
 
 Use accountless instant loans for new borrow flows unless you need profile-level position management. Use account-based flows when your app owns the full lending dashboard experience.
 
@@ -238,6 +238,10 @@ The SDK enforces product minimums before borrow creation:
 | USDT | `1_000_000n` base units |
 
 Use `getMinimumBorrowAmount(asset)` to display the same minimum that `client.quote.calculateLtv(...)`, `client.quote.getQuote(...)`, `client.instantLoans.create(...)`, and `client.lending.prepareBorrow(...)` enforce.
+
+### Profile full withdraw amounts
+
+For profile-based withdraw flows, call `client.positions.getFullWithdrawAmount(profileId, poolId)` before building the withdraw request. The helper returns `{ amount, decimals }`: pass `amount` to `client.lending.withdraw(...)` or `client.lending.prepareWithdraw(...)`, and use `decimals` for display formatting. Do not add `earnedInterest`; the returned amount already uses the current supplied balance.
 
 ## Response Fields
 

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -1970,6 +1970,9 @@ describe("PositionsModule", () => {
     // given
     const BTC_POOL_ID = "pool-btc";
     const USDT_POOL_ID = "pool-usdt";
+    const BTC_DEPOSITED_NATIVE_NOW = 200_000_000n;
+    const BTC_TOTAL_EARNED_INTEREST = 10_000_000n;
+    const BTC_EARNED_SINCE_SNAPSHOT = 1_000_000n;
     vi.spyOn(Actor, "createActor").mockReturnValue({
       get_profile_stats: vi.fn().mockResolvedValue({
         debt: 0n,
@@ -1986,7 +1989,9 @@ describe("PositionsModule", () => {
         .fn()
         .mockResolvedValueOnce([
           makePositionView({
-            deposited_native_now: 200_000_000n,
+            deposited_native_now: BTC_DEPOSITED_NATIVE_NOW,
+            total_earned_interest: BTC_TOTAL_EARNED_INTEREST,
+            earned_since_snapshot: BTC_EARNED_SINCE_SNAPSHOT,
             debt_native_now: 0n,
             pool_id: { toText: () => BTC_POOL_ID },
           }),

--- a/packages/client/src/_internal/modules.test.ts
+++ b/packages/client/src/_internal/modules.test.ts
@@ -2081,6 +2081,54 @@ describe("PositionsModule", () => {
     expect(usdtReserve?.priceUsd).toBe(1);
   });
 
+  test("returns zero full withdraw amount when no position exists", async () => {
+    // given
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      get_position: vi.fn().mockResolvedValue([]),
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const withdraw = await client.positions.getFullWithdrawAmount(
+      PROFILE_ID,
+      POOL_ID
+    );
+
+    // then
+    expect(withdraw).toEqual({ amount: 0n, decimals: 0n });
+  });
+
+  test("returns current deposited amount as full withdraw amount", async () => {
+    // given
+    const DEPOSITED_NATIVE_NOW = 1_100_000n;
+    const TOTAL_EARNED_INTEREST = 100_000n;
+    const EARNED_SINCE_SNAPSHOT = 10_000n;
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      get_position: vi.fn().mockResolvedValue([
+        makePositionView({
+          asset: { USDT: null },
+          deposited_native_now: DEPOSITED_NATIVE_NOW,
+          total_earned_interest: TOTAL_EARNED_INTEREST,
+          earned_since_snapshot: EARNED_SINCE_SNAPSHOT,
+        }),
+      ]),
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const withdraw = await client.positions.getFullWithdrawAmount(
+      PROFILE_ID,
+      POOL_ID
+    );
+
+    // then
+    const EXPECTED_DECIMALS = 6n;
+    expect(withdraw).toEqual({
+      amount: DEPOSITED_NATIVE_NOW,
+      decimals: EXPECTED_DECIMALS,
+    });
+  });
+
   test("returns zero max repay amount when no position exists", async () => {
     // given
     vi.spyOn(Actor, "createActor").mockReturnValue({

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -199,6 +199,7 @@ export type {
 export { MarketModule } from "./modules/market";
 export type {
   BorrowingPower,
+  FullWithdrawAmount,
   HealthFactor,
   MaxRepayAmount,
   Position,

--- a/packages/client/src/modules/positions/index.ts
+++ b/packages/client/src/modules/positions/index.ts
@@ -1,6 +1,7 @@
 export { PositionsModule } from "./positions";
 export type {
   BorrowingPower,
+  FullWithdrawAmount,
   HealthFactor,
   MaxRepayAmount,
   Position,

--- a/packages/client/src/modules/positions/positions.ts
+++ b/packages/client/src/modules/positions/positions.ts
@@ -11,6 +11,7 @@ import {
   USD_VALUE_SCALE_DECIMALS,
 } from "./mappers";
 import type {
+  FullWithdrawAmount,
   HealthFactor,
   MaxRepayAmount,
   Position,
@@ -252,6 +253,29 @@ export class PositionsModule {
     const buffered = (rawDebt * (BPS_SCALE + bufferBps)) / BPS_SCALE;
 
     return { amount: buffered, decimals: position.borrowedDecimals };
+  }
+
+  /**
+   * Returns the current full withdraw amount for a position.
+   *
+   * `Position.deposited` already reflects the current supplied balance at the
+   * latest lending index; do not add `earnedInterest` to this amount.
+   * Pass `amount` to withdraw calls and use `decimals` for display formatting.
+   *
+   * @param profileId - The Liquidium profile principal text.
+   * @param poolId - The pool principal text.
+   * @returns Full withdraw amount in the supplied asset's base units.
+   */
+  async getFullWithdrawAmount(
+    profileId: string,
+    poolId: string
+  ): Promise<FullWithdrawAmount> {
+    const position = await this.getPosition(profileId, poolId);
+    if (!position) {
+      return { amount: 0n, decimals: 0n };
+    }
+
+    return { amount: position.deposited, decimals: position.depositedDecimals };
   }
 }
 

--- a/packages/client/src/modules/positions/positions.ts
+++ b/packages/client/src/modules/positions/positions.ts
@@ -211,7 +211,7 @@ export class PositionsModule {
           pool,
           priceUsd,
           suppliedUsd: nativeAmountToUsdScaled(
-            position.deposited + position.earnedInterest,
+            position.deposited,
             position.depositedDecimals,
             priceUsd
           ),

--- a/packages/client/src/modules/positions/types.ts
+++ b/packages/client/src/modules/positions/types.ts
@@ -7,7 +7,7 @@ export interface Position {
   poolId: string;
   /** Pool asset symbol. */
   asset: MarketAsset;
-  /** Supplied principal in base units. */
+  /** Current supplied amount in base units. */
   deposited: bigint;
   /** Decimal scale for supplied amounts. */
   depositedDecimals: bigint;
@@ -98,6 +98,14 @@ export interface UserReserve {
 /** Full repayment amount for a position, including any requested buffer. */
 export interface MaxRepayAmount {
   /** Amount to repay in the borrowed asset's base units. */
+  amount: bigint;
+  /** Decimal scale for `amount`. */
+  decimals: bigint;
+}
+
+/** Full withdraw amount for a position. */
+export interface FullWithdrawAmount {
+  /** Amount to withdraw in the supplied asset's base units. */
   amount: bigint;
   /** Decimal scale for `amount`. */
   decimals: bigint;

--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -232,7 +232,12 @@ client.positions.getUserStats(profileId);
 client.positions.getUserPositionSummary(profileId);  // aggregate: collateral, debt, availableBorrows, netWorth, LTV, HF
 client.positions.getUserReserves(profileId);         // per-reserve view joined with pool + price data
 client.positions.getMaxRepayAmount(profileId, poolId, bufferBps?); // full-repay amount with accrual buffer
+client.positions.getFullWithdrawAmount(profileId, poolId);         // current supplied balance for full withdraw
 ```
+
+`getFullWithdrawAmount(...)` returns `{ amount, decimals }`. Pass `amount` to
+`client.lending.withdraw(...)` or `prepareWithdraw(...)`; use `decimals` only
+for UI formatting. Do not add `earnedInterest` to the returned amount.
 
 ### activities
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper to get a position’s full withdraw amount (returns { amount, decimals }) for withdraw flows.

* **Documentation**
  * Updated SDK docs, examples, and method templates with usage and guidance for the new helper and the updated positions listing call.

* **Bug Fixes**
  * Fixed reserve USD valuation to avoid double-counting supplied interest.

* **Tests**
  * Added unit tests covering full withdraw amount behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->