### PR TITLE
refactor(client): make unsupported pool filtering explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Instant-loan integrations use this sequence:
 
 `client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, current position state, an initial deposit quote with its transfer target, and a repayment quote with its transfer target. Repayment amount fields are zero when the loan has no debt. Users do not manage the generated profile.
 
+`client.market.listPools()` returns only pools whose asset and chain variants are supported by this SDK version. Canister pools for unsupported variants such as `ICP` or `SOL` are omitted from the returned list.
+
 ## Core API
 
 ### `client.instantLoans.create(request)`

--- a/docs/api-reference/generated/classes/LendingModule.md
+++ b/docs/api-reference/generated/classes/LendingModule.md
@@ -6,7 +6,7 @@
 
 # Class: LendingModule
 
-Defined in: [packages/client/src/modules/lending/lending.ts:209](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L209)
+Defined in: [packages/client/src/modules/lending/lending.ts:93](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L93)
 
 Borrow, withdraw, supply, inflow reporting, and fee-estimation helpers.
 
@@ -16,7 +16,7 @@ Borrow, withdraw, supply, inflow reporting, and fee-estimation helpers.
 
 > **new LendingModule**(`canisterContext`, `apiClient`, `evmReadClient`): `LendingModule`
 
-Defined in: [packages/client/src/modules/lending/lending.ts:210](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L210)
+Defined in: [packages/client/src/modules/lending/lending.ts:94](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L94)
 
 #### Parameters
 
@@ -42,7 +42,7 @@ Defined in: [packages/client/src/modules/lending/lending.ts:210](https://github.
 
 > **borrow**(`params`): `Promise`\<[`BorrowOutflowDetails`](../type-aliases/BorrowOutflowDetails.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:504](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L504)
+Defined in: [packages/client/src/modules/lending/lending.ts:388](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L388)
 
 Creates a borrow outflow using the provided wallet adapter.
 
@@ -73,7 +73,7 @@ poll for it. Use history or app-level polling if you need the chain transaction 
 
 > **estimateInflowFee**(`request`): `Promise`\<[`InflowFeeEstimate`](../interfaces/InflowFeeEstimate.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:724](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L724)
+Defined in: [packages/client/src/modules/lending/lending.ts:481](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L481)
 
 Estimates the network/deposit fee for an inflow target.
 
@@ -100,7 +100,7 @@ Total fee estimate rounded up in the asset's base units.
 
 > **getDepositAddress**(`request`): `Promise`\<`string`\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:684](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L684)
+Defined in: [packages/client/src/modules/lending/lending.ts:441](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L441)
 
 Returns the read-only deposit address for an ETH stablecoin inflow target.
 
@@ -127,7 +127,7 @@ The EVM deposit address for the derived account.
 
 > **getEvmSupplyContext**(`request`): `Promise`\<[`EvmSupplyContext`](../interfaces/EvmSupplyContext.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:599](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L599)
+Defined in: [packages/client/src/modules/lending/lending.ts:426](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L426)
 
 Fetches ERC-20 supply planning data with the configured EVM read client.
 
@@ -154,7 +154,7 @@ Locally computed [EvmSupplyContext](../interfaces/EvmSupplyContext.md) for appro
 
 > **isBorrowingDisabled**(): `Promise`\<`boolean`\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:1093](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L1093)
+Defined in: [packages/client/src/modules/lending/lending.ts:548](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L548)
 
 Returns whether borrowing is currently disabled by the protocol.
 
@@ -170,7 +170,7 @@ Returns whether borrowing is currently disabled by the protocol.
 
 > **prepareBorrow**(`request`): `Promise`\<[`BorrowAction`](../interfaces/BorrowAction.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:364](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L364)
+Defined in: [packages/client/src/modules/lending/lending.ts:248](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L248)
 
 Prepares a borrow action that can be signed and submitted later.
 
@@ -196,7 +196,7 @@ A signable [BorrowAction](../interfaces/BorrowAction.md) with `submit` wired to 
 
 > **prepareWithdraw**(`request`): `Promise`\<[`WithdrawAction`](../interfaces/WithdrawAction.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:224](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L224)
+Defined in: [packages/client/src/modules/lending/lending.ts:108](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L108)
 
 Prepares a withdraw action that can be signed and submitted later.
 
@@ -222,7 +222,7 @@ A signable [WithdrawAction](../interfaces/WithdrawAction.md) with `submit` wired
 
 > **submitInflow**(`request`): `Promise`\<[`SubmitInflowResponse`](../interfaces/SubmitInflowResponse.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:1073](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L1073)
+Defined in: [packages/client/src/modules/lending/lending.ts:528](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L528)
 
 Submits an inflow transaction id for faster indexing.
 
@@ -248,7 +248,7 @@ Acknowledgement including the submitted `txid`.
 
 > **supply**(`request`): `Promise`\<[`SupplyFlow`](../interfaces/SupplyFlow.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:529](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L529)
+Defined in: [packages/client/src/modules/lending/lending.ts:413](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L413)
 
 Resolves a supply target for a deposit or repayment and optionally broadcasts it.
 
@@ -278,7 +278,7 @@ A [SupplyFlow](../interfaces/SupplyFlow.md) receipt with `type`, `target`, `subm
 
 > **withdraw**(`params`): `Promise`\<[`WithdrawOutflowDetails`](../type-aliases/WithdrawOutflowDetails.md)\>
 
-Defined in: [packages/client/src/modules/lending/lending.ts:344](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L344)
+Defined in: [packages/client/src/modules/lending/lending.ts:228](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/lending/lending.ts#L228)
 
 Creates a withdraw outflow using the provided wallet adapter.
 

--- a/docs/api-reference/generated/classes/MarketModule.md
+++ b/docs/api-reference/generated/classes/MarketModule.md
@@ -6,7 +6,7 @@
 
 # Class: MarketModule
 
-Defined in: [packages/client/src/modules/market/market.ts:24](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L24)
+Defined in: [packages/client/src/modules/market/market.ts:25](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L25)
 
 Pool metadata, prices, and current rate helpers.
 
@@ -16,7 +16,7 @@ Pool metadata, prices, and current rate helpers.
 
 > **new MarketModule**(`canisterContext`, `apiClient`): `MarketModule`
 
-Defined in: [packages/client/src/modules/market/market.ts:25](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L25)
+Defined in: [packages/client/src/modules/market/market.ts:26](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L26)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Defined in: [packages/client/src/modules/market/market.ts:25](https://github.com
 
 > **findPool**(`query`): `Promise`\<[`Pool`](../interfaces/Pool.md)\>
 
-Defined in: [packages/client/src/modules/market/market.ts:96](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L96)
+Defined in: [packages/client/src/modules/market/market.ts:97](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L97)
 
 Resolves a single pool for the given asset and chain pair.
 
@@ -62,7 +62,7 @@ The single pool that matches the requested asset and chain.
 
 > **getAssetPrices**(): `Promise`\<[`AssetPrices`](../type-aliases/AssetPrices.md)\>
 
-Defined in: [packages/client/src/modules/market/market.ts:72](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L72)
+Defined in: [packages/client/src/modules/market/market.ts:73](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L73)
 
 Returns the latest asset prices reported by the protocol.
 
@@ -78,7 +78,7 @@ The latest protocol price map keyed by market asset symbol.
 
 > **getPoolRate**(`poolId`): `Promise`\<[`PoolRate`](../interfaces/PoolRate.md)\>
 
-Defined in: [packages/client/src/modules/market/market.ts:138](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L138)
+Defined in: [packages/client/src/modules/market/market.ts:139](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L139)
 
 Returns the current borrow, lend, and utilization rates for a pool.
 
@@ -102,7 +102,7 @@ The borrow, lend, and utilization rates for the requested pool.
 
 > **getReserveData**(`query`): `Promise`\<[`Pool`](../interfaces/Pool.md)\>
 
-Defined in: [packages/client/src/modules/market/market.ts:128](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L128)
+Defined in: [packages/client/src/modules/market/market.ts:129](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L129)
 
 Returns the full pool record for the given asset and chain pair.
 
@@ -129,12 +129,14 @@ The matching pool enriched with current rate data.
 
 > **listPools**(): `Promise`\<[`Pool`](../interfaces/Pool.md)[]\>
 
-Defined in: [packages/client/src/modules/market/market.ts:35](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L35)
+Defined in: [packages/client/src/modules/market/market.ts:38](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/market/market.ts#L38)
 
-Lists all pools with their current rates.
+Lists SDK-supported pools with their current rates.
+
+Unsupported asset or chain variants returned by the canister are omitted.
 
 #### Returns
 
 `Promise`\<[`Pool`](../interfaces/Pool.md)[]\>
 
-All configured lending pools enriched with their current rate data.
+Supported lending pools enriched with their current rate data.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -160,6 +160,8 @@ Instant-loan integrations use this sequence:
 
 `client.instantLoans.create(...)` and `client.instantLoans.get(...)` return the generated Liquidium profile, current position state, an initial deposit quote with its transfer target, and a repayment quote with its transfer target. Repayment amount fields are zero when the loan has no debt. Users do not manage the generated profile.
 
+`client.market.listPools()` returns only pools whose asset and chain variants are supported by this SDK version. Canister pools for unsupported variants such as `ICP` or `SOL` are omitted from the returned list.
+
 ## Core API
 
 ### `client.instantLoans.create(request)`

--- a/packages/client/src/core/canisters/instant-loans/flexible-actor.test.ts
+++ b/packages/client/src/core/canisters/instant-loans/flexible-actor.test.ts
@@ -91,7 +91,7 @@ describe("decodeFlexibleInstantLoanRecord", () => {
 
   test("should decode a loan with hashed variant keys from IDL.Unknown", () => {
     // given
-    const lendHash = idlLabelToId("SOL");
+    const lendHash = idlLabelToId("USDT");
     const borrowHash = idlLabelToId("USDT");
     const record = createFlexibleInstantLoanRecord({
       lend_asset: { [`_${lendHash}_`]: null },
@@ -103,8 +103,21 @@ describe("decodeFlexibleInstantLoanRecord", () => {
 
     // then
     expect(decoded).not.toBeNull();
-    expect(decoded?.lend_asset).toBe("SOL");
+    expect(decoded?.lend_asset).toBe("USDT");
     expect(decoded?.borrow_asset).toBe("USDT");
+  });
+
+  test("should return null for an unsupported SOL asset tag", () => {
+    // given
+    const record = createFlexibleInstantLoanRecord({
+      lend_asset: { SOL: null },
+    });
+
+    // when
+    const decoded = decodeFlexibleInstantLoanRecord(record);
+
+    // then
+    expect(decoded).toBeNull();
   });
 
   test("should return null for an unknown lend asset tag", () => {
@@ -165,7 +178,7 @@ describe("decodeFlexibleHeadlessLoanEvent", () => {
 
   test("should decode a LoanCreated event with hashed variant keys", () => {
     // given
-    const lendHash = idlLabelToId("SOL");
+    const lendHash = idlLabelToId("USDT");
     const borrowHash = idlLabelToId("USDT");
     const event = createFlexibleHeadlessLoanEvent({
       event_type: {
@@ -193,7 +206,7 @@ describe("decodeFlexibleHeadlessLoanEvent", () => {
     const eventType = decoded?.event_type;
     expect(eventType).toBeDefined();
     if (eventType && "LoanCreated" in eventType) {
-      expect(eventType.LoanCreated.lend_asset).toBe("SOL");
+      expect(eventType.LoanCreated.lend_asset).toBe("USDT");
       expect(eventType.LoanCreated.borrow_asset).toBe("USDT");
     }
   });

--- a/packages/client/src/core/canisters/lending/flexible-actor.test.ts
+++ b/packages/client/src/core/canisters/lending/flexible-actor.test.ts
@@ -135,9 +135,23 @@ describe("decodeFlexiblePool", () => {
     expect(decoded).toBeNull();
   });
 
+  test("should return null for an unsupported SOL pool", () => {
+    // given
+    const pool = createFlexiblePool({
+      asset: { SOL: null },
+      chain: { SOL: null },
+    });
+
+    // when
+    const decoded = decodeFlexiblePool(pool);
+
+    // then
+    expect(decoded).toBeNull();
+  });
+
   test("should decode a pool with hashed variant keys from IDL.Unknown", () => {
     // given
-    const assetHash = idlLabelToId("SOL");
+    const assetHash = idlLabelToId("USDC");
     const chainHash = idlLabelToId("ETH");
     const pool = createFlexiblePool({
       asset: { [`_${assetHash}_`]: null },
@@ -149,7 +163,7 @@ describe("decodeFlexiblePool", () => {
 
     // then
     expect(decoded).not.toBeNull();
-    expect(decoded?.asset).toBe("SOL");
+    expect(decoded?.asset).toBe("USDC");
     expect(decoded?.chain).toBe("ETH");
   });
 
@@ -203,7 +217,7 @@ describe("decodeFlexiblePosition", () => {
 
   test("should decode a position with a hashed variant key", () => {
     // given
-    const assetHash = idlLabelToId("SOL");
+    const assetHash = idlLabelToId("USDT");
     const position = createFlexiblePosition({
       asset: { [`_${assetHash}_`]: null },
     });
@@ -213,7 +227,7 @@ describe("decodeFlexiblePosition", () => {
 
     // then
     expect(decoded).not.toBeNull();
-    expect(decoded?.asset).toBe("SOL");
+    expect(decoded?.asset).toBe("USDT");
   });
 
   test("should return null for an unsupported ICP position", () => {

--- a/packages/client/src/core/utils/variant-tags.test.ts
+++ b/packages/client/src/core/utils/variant-tags.test.ts
@@ -18,7 +18,19 @@ describe("extractVariantTag", () => {
     expect(tag).toBe("BTC");
   });
 
-  test("should decode a hashed variant key from IDL.Unknown", () => {
+  test("should decode a supported hashed variant key from IDL.Unknown", () => {
+    // given
+    const hash = idlLabelToId("USDT");
+    const variant = { [`_${hash}_`]: null };
+
+    // when
+    const tag = extractVariantTag(variant, KNOWN_ASSET_TAGS);
+
+    // then
+    expect(tag).toBe("USDT");
+  });
+
+  test("should return null for an unsupported hashed tag", () => {
     // given
     const hash = idlLabelToId("SOL");
     const variant = { [`_${hash}_`]: null };
@@ -27,7 +39,7 @@ describe("extractVariantTag", () => {
     const tag = extractVariantTag(variant, KNOWN_ASSET_TAGS);
 
     // then
-    expect(tag).toBe("SOL");
+    expect(tag).toBeNull();
   });
 
   test("should return null for an unknown tag", () => {

--- a/packages/client/src/core/utils/variant-tags.ts
+++ b/packages/client/src/core/utils/variant-tags.ts
@@ -2,8 +2,8 @@ import { idlLabelToId } from "@icp-sdk/core/candid";
 
 // Asset and chain tags supported by this SDK version. Unknown tags returned by
 // the canister are ignored rather than causing the whole call to fail.
-export const KNOWN_ASSET_TAGS = ["BTC", "SOL", "USDC", "USDT"] as const;
-export const KNOWN_CHAIN_TAGS = ["BTC", "ETH", "SOL"] as const;
+export const KNOWN_ASSET_TAGS = ["BTC", "USDC", "USDT"] as const;
+export const KNOWN_CHAIN_TAGS = ["BTC", "ETH"] as const;
 
 export type KnownAssetTag = (typeof KNOWN_ASSET_TAGS)[number];
 export type KnownChainTag = (typeof KNOWN_CHAIN_TAGS)[number];

--- a/packages/client/src/modules/market/_internal/market.test.ts
+++ b/packages/client/src/modules/market/_internal/market.test.ts
@@ -131,7 +131,7 @@ describe("MarketModule", () => {
     });
   });
 
-  test("returns dynamic asset and chain values from the canister", async () => {
+  test("excludes unsupported SOL pools returned by the canister", async () => {
     // given
     vi.spyOn(Actor, "createActor").mockReturnValue({
       list_pools: vi.fn().mockResolvedValue([
@@ -168,10 +168,7 @@ describe("MarketModule", () => {
     const pools = await client.market.listPools();
 
     // then
-    expect(pools[0]).toMatchObject({
-      asset: "SOL",
-      chain: "SOL",
-    });
+    expect(pools).toHaveLength(0);
   });
 
   test("ignores pools with unsupported assets instead of failing", async () => {

--- a/packages/client/src/modules/market/market.ts
+++ b/packages/client/src/modules/market/market.ts
@@ -7,6 +7,7 @@ import {
   createFlexibleLendingActor,
   type DecodedPool,
   decodeFlexiblePool,
+  type FlexiblePool,
 } from "../../core/canisters/lending/flexible-actor";
 import { LiquidiumError, LiquidiumErrorCode } from "../../core/errors";
 import type { ApiClient } from "../../core/transports/api-client";
@@ -28,9 +29,11 @@ export class MarketModule {
   ) {}
 
   /**
-   * Lists all pools with their current rates.
+   * Lists SDK-supported pools with their current rates.
    *
-   * @returns All configured lending pools enriched with their current rate data.
+   * Unsupported asset or chain variants returned by the canister are omitted.
+   *
+   * @returns Supported lending pools enriched with their current rate data.
    */
   async listPools(): Promise<Pool[]> {
     void this.apiClient;
@@ -39,9 +42,7 @@ export class MarketModule {
       const flexibleActor = createFlexibleLendingActor(this.canisterContext);
       const rawPools = await flexibleActor.list_pools();
 
-      const decodedPools = rawPools
-        .map(decodeFlexiblePool)
-        .filter((pool): pool is DecodedPool => pool !== null);
+      const decodedPools = decodeSupportedFlexiblePools(rawPools);
 
       return await Promise.all(
         decodedPools.map(async (pool) => {
@@ -161,4 +162,22 @@ export class MarketModule {
       );
     }
   }
+}
+
+function decodeSupportedFlexiblePools(rawPools: FlexiblePool[]): DecodedPool[] {
+  const decodedPools: DecodedPool[] = [];
+
+  for (const rawPool of rawPools) {
+    const decodedPool = decodeFlexiblePool(rawPool);
+
+    // The canister may expose assets/chains before the SDK supports their flows.
+    // Keep market.listPools() scoped to pools this SDK can safely map and use.
+    if (!decodedPool) {
+      continue;
+    }
+
+    decodedPools.push(decodedPool);
+  }
+
+  return decodedPools;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `client.market.listPools()` now excludes pools with unsupported asset or chain variants, so results only include pools your SDK version can handle.
  * Decoding behavior is more consistent for unsupported variant tags, returning no data instead of partially decoded entries.

* **Documentation**
  * Clarified the pool listing behavior in the client README so unsupported pools are clearly described as omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->