### PR TITLE
chore(client): prepare 0.5.1 release

### DIFF
--- a/.changeset/fix-indexed-pool-totals.md
+++ b/.changeset/fix-indexed-pool-totals.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": patch
----
-
-Apply lending and borrow indexes when mapping current pool totals.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,12 @@ Released changes for `@liquidium/client`. This page is generated from [`packages
 
 ## @liquidium/client
 
+### 0.5.1
+
+#### Patch Changes
+
+- 88cfd04: Apply lending and borrow indexes when mapping current pool totals.
+
 ### 0.5.0
 
 #### Minor Changes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @liquidium/client
 
+## 0.5.1
+
+### Patch Changes
+
+- 88cfd04: Apply lending and borrow indexes when mapping current pool totals.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquidium/client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The official client for the Liquidium protocol",
   "keywords": [
     "liquidium",


### PR DESCRIPTION
## Summary

- bump `@liquidium/client` to 0.5.1
- add package and docs changelog entries
- consume the pool totals patch changeset

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of current pool total calculations by applying lending and borrowing adjustments.

* **Release**
  * Updated the client package to version 0.5.1.

* **Documentation**
  * Added release notes describing the pool total calculation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->