### PR TITLE
fix: hide supplied position when under dust amount

### DIFF
--- a/.changeset/hide-supplied-position-dust.md
+++ b/.changeset/hide-supplied-position-dust.md
@@ -1,0 +1,5 @@
+---
+"@liquidium/client": patch
+---
+
+Hide supplied balances below each pool's dust threshold while preserving positions with active debt.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ pnpm typecheck
 pnpm test
 ```
 
+Run the live supplied-position dust test with a profile and pool that contain a
+supplied-only balance below the pool's same-asset dust threshold:
+
+```bash
+LIQUIDIUM_E2E_DUST_PROFILE_ID=<profile-id> \
+LIQUIDIUM_E2E_DUST_POOL_ID=<pool-id> \
+LIQUIDIUM_LIVE_E2E=1 \
+pnpm exec vitest run --project client-e2e e2e/positions.e2e.test.ts
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ supplied-only balance below the pool's same-asset dust threshold:
 
 ```bash
 LIQUIDIUM_E2E_DUST_PROFILE_ID=<profile-id> \
-LIQUIDIUM_E2E_DUST_POOL_ID=<pool-id> \
 LIQUIDIUM_LIVE_E2E=1 \
 pnpm exec vitest run --project client-e2e e2e/positions.e2e.test.ts
 ```

--- a/README.md
+++ b/README.md
@@ -82,15 +82,6 @@ pnpm typecheck
 pnpm test
 ```
 
-Run the live supplied-position dust test with a profile and pool that contain a
-supplied-only balance below the pool's same-asset dust threshold:
-
-```bash
-LIQUIDIUM_E2E_DUST_PROFILE_ID=<profile-id> \
-LIQUIDIUM_LIVE_E2E=1 \
-pnpm exec vitest run --project client-e2e e2e/positions.e2e.test.ts
-```
-
 ## License
 
 MIT

--- a/docs/api-reference/generated/classes/PositionsModule.md
+++ b/docs/api-reference/generated/classes/PositionsModule.md
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/positions/positions.ts:34](https://gith
 
 > **getFullWithdrawAmount**(`profileId`, `poolId`): `Promise`\<[`FullWithdrawAmount`](../interfaces/FullWithdrawAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:301](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L301)
+Defined in: [packages/client/src/modules/positions/positions.ts:299](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L299)
 
 Returns the current full withdraw amount for a position.
 
@@ -80,7 +80,7 @@ Full withdraw amount in the supplied asset's base units.
 
 > **getHealthFactor**(`profileId`): `Promise`\<[`HealthFactor`](../interfaces/HealthFactor.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:131](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L131)
+Defined in: [packages/client/src/modules/positions/positions.ts:129](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L129)
 
 Returns the current health factor for a profile.
 
@@ -104,7 +104,7 @@ The current health factor for the requested profile.
 
 > **getMaxRepayAmount**(`profileId`, `poolId`, `bufferBps?`): `Promise`\<[`MaxRepayAmount`](../interfaces/MaxRepayAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:270](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L270)
+Defined in: [packages/client/src/modules/positions/positions.ts:268](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L268)
 
 Returns the full repayment amount for a position, with a small buffer to
 account for interest that accrues between quote and submit.
@@ -171,7 +171,7 @@ The position for the requested profile and pool, or `null` when no position exis
 
 > **getUserPositionSummary**(`profileId`): `Promise`\<[`UserPositionSummary`](../interfaces/UserPositionSummary.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:185](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L185)
+Defined in: [packages/client/src/modules/positions/positions.ts:183](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L183)
 
 Returns an aggregate summary of a profile's position.
 
@@ -200,7 +200,7 @@ Derived position summary for the requested profile.
 
 > **getUserReserves**(`profileId`): `Promise`\<[`UserReserve`](../interfaces/UserReserve.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:221](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L221)
+Defined in: [packages/client/src/modules/positions/positions.ts:219](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L219)
 
 Returns the per-reserve breakdown of a profile's supplies and borrows,
 joined with pool metadata, rates, and current USD prices.
@@ -227,7 +227,7 @@ Per-reserve position rows joined with pool metadata and USD values.
 
 > **getUserStats**(`profileId`): `Promise`\<[`UserStats`](../interfaces/UserStats.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:158](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L158)
+Defined in: [packages/client/src/modules/positions/positions.ts:156](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L156)
 
 Returns aggregate borrowing and collateral stats for a profile.
 
@@ -251,11 +251,10 @@ Aggregate debt, collateral, and borrowing power metrics for the requested profil
 
 > **listPositions**(`profileId`): `Promise`\<[`Position`](../interfaces/Position.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:81](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L81)
+Defined in: [packages/client/src/modules/positions/positions.ts:80](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L80)
 
-Lists visible positions for a profile. Supplied-only positions below their
-pool's same-asset dust threshold are omitted, while positions with debt are
-retained.
+Lists visible positions for a profile. Supply balances below their pool's
+same-asset dust threshold are hidden without removing active debt.
 
 #### Parameters
 

--- a/docs/api-reference/generated/classes/PositionsModule.md
+++ b/docs/api-reference/generated/classes/PositionsModule.md
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/positions/positions.ts:34](https://gith
 
 > **getFullWithdrawAmount**(`profileId`, `poolId`): `Promise`\<[`FullWithdrawAmount`](../interfaces/FullWithdrawAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:299](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L299)
+Defined in: [packages/client/src/modules/positions/positions.ts:304](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L304)
 
 Returns the current full withdraw amount for a position.
 
@@ -80,7 +80,7 @@ Full withdraw amount in the supplied asset's base units.
 
 > **getHealthFactor**(`profileId`): `Promise`\<[`HealthFactor`](../interfaces/HealthFactor.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:129](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L129)
+Defined in: [packages/client/src/modules/positions/positions.ts:130](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L130)
 
 Returns the current health factor for a profile.
 
@@ -104,7 +104,7 @@ The current health factor for the requested profile.
 
 > **getMaxRepayAmount**(`profileId`, `poolId`, `bufferBps?`): `Promise`\<[`MaxRepayAmount`](../interfaces/MaxRepayAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:268](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L268)
+Defined in: [packages/client/src/modules/positions/positions.ts:273](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L273)
 
 Returns the full repayment amount for a position, with a small buffer to
 account for interest that accrues between quote and submit.
@@ -171,7 +171,7 @@ The position for the requested profile and pool, or `null` when no position exis
 
 > **getUserPositionSummary**(`profileId`): `Promise`\<[`UserPositionSummary`](../interfaces/UserPositionSummary.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:183](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L183)
+Defined in: [packages/client/src/modules/positions/positions.ts:184](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L184)
 
 Returns an aggregate summary of a profile's position.
 
@@ -200,10 +200,14 @@ Derived position summary for the requested profile.
 
 > **getUserReserves**(`profileId`): `Promise`\<[`UserReserve`](../interfaces/UserReserve.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:219](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L219)
+Defined in: [packages/client/src/modules/positions/positions.ts:224](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L224)
 
 Returns the per-reserve breakdown of a profile's supplies and borrows,
 joined with pool metadata, rates, and current USD prices.
+
+Supplied-only reserves below their pool's same-asset dust threshold are
+omitted. Reserves with active debt remain, with their supplied amount and
+earned interest set to zero when the supplied balance is below the threshold.
 
 USD values are scaled to 27 decimals.
 
@@ -227,7 +231,7 @@ Per-reserve position rows joined with pool metadata and USD values.
 
 > **getUserStats**(`profileId`): `Promise`\<[`UserStats`](../interfaces/UserStats.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:156](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L156)
+Defined in: [packages/client/src/modules/positions/positions.ts:157](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L157)
 
 Returns aggregate borrowing and collateral stats for a profile.
 

--- a/docs/api-reference/generated/classes/PositionsModule.md
+++ b/docs/api-reference/generated/classes/PositionsModule.md
@@ -46,7 +46,7 @@ Defined in: [packages/client/src/modules/positions/positions.ts:34](https://gith
 
 > **getFullWithdrawAmount**(`profileId`, `poolId`): `Promise`\<[`FullWithdrawAmount`](../interfaces/FullWithdrawAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:283](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L283)
+Defined in: [packages/client/src/modules/positions/positions.ts:301](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L301)
 
 Returns the current full withdraw amount for a position.
 
@@ -80,7 +80,7 @@ Full withdraw amount in the supplied asset's base units.
 
 > **getHealthFactor**(`profileId`): `Promise`\<[`HealthFactor`](../interfaces/HealthFactor.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:113](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L113)
+Defined in: [packages/client/src/modules/positions/positions.ts:131](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L131)
 
 Returns the current health factor for a profile.
 
@@ -104,7 +104,7 @@ The current health factor for the requested profile.
 
 > **getMaxRepayAmount**(`profileId`, `poolId`, `bufferBps?`): `Promise`\<[`MaxRepayAmount`](../interfaces/MaxRepayAmount.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:252](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L252)
+Defined in: [packages/client/src/modules/positions/positions.ts:270](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L270)
 
 Returns the full repayment amount for a position, with a small buffer to
 account for interest that accrues between quote and submit.
@@ -171,7 +171,7 @@ The position for the requested profile and pool, or `null` when no position exis
 
 > **getUserPositionSummary**(`profileId`): `Promise`\<[`UserPositionSummary`](../interfaces/UserPositionSummary.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:167](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L167)
+Defined in: [packages/client/src/modules/positions/positions.ts:185](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L185)
 
 Returns an aggregate summary of a profile's position.
 
@@ -200,7 +200,7 @@ Derived position summary for the requested profile.
 
 > **getUserReserves**(`profileId`): `Promise`\<[`UserReserve`](../interfaces/UserReserve.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:203](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L203)
+Defined in: [packages/client/src/modules/positions/positions.ts:221](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L221)
 
 Returns the per-reserve breakdown of a profile's supplies and borrows,
 joined with pool metadata, rates, and current USD prices.
@@ -227,7 +227,7 @@ Per-reserve position rows joined with pool metadata and USD values.
 
 > **getUserStats**(`profileId`): `Promise`\<[`UserStats`](../interfaces/UserStats.md)\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:140](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L140)
+Defined in: [packages/client/src/modules/positions/positions.ts:158](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L158)
 
 Returns aggregate borrowing and collateral stats for a profile.
 
@@ -251,9 +251,11 @@ Aggregate debt, collateral, and borrowing power metrics for the requested profil
 
 > **listPositions**(`profileId`): `Promise`\<[`Position`](../interfaces/Position.md)[]\>
 
-Defined in: [packages/client/src/modules/positions/positions.ts:79](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L79)
+Defined in: [packages/client/src/modules/positions/positions.ts:81](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/modules/positions/positions.ts#L81)
 
-Lists all positions for a profile.
+Lists visible positions for a profile. Supplied-only positions below their
+pool's same-asset dust threshold are omitted, while positions with debt are
+retained.
 
 #### Parameters
 
@@ -267,4 +269,4 @@ The Liquidium profile principal text.
 
 `Promise`\<[`Position`](../interfaces/Position.md)[]\>
 
-All positions currently associated with the requested profile.
+Visible positions currently associated with the requested profile.

--- a/e2e/positions.e2e.test.ts
+++ b/e2e/positions.e2e.test.ts
@@ -3,41 +3,66 @@ import { LiquidiumClient } from "../packages/client/src";
 import { describeLive } from "./_internal/live";
 
 const DUST_PROFILE_ID = process.env.LIQUIDIUM_E2E_DUST_PROFILE_ID ?? "";
-const DUST_POOL_ID = process.env.LIQUIDIUM_E2E_DUST_POOL_ID ?? "";
-const HAS_DUST_POSITION_FIXTURE = DUST_PROFILE_ID !== "" && DUST_POOL_ID !== "";
+const HAS_DUST_POSITION_FIXTURE = DUST_PROFILE_ID !== "";
 
 describeLive("live positions e2e", () => {
   test.skipIf(!HAS_DUST_POSITION_FIXTURE)(
-    "should omit a supplied-only position below its pool dust threshold",
+    "should hide dust supply without removing the debt position",
     async () => {
       // given
       const client = new LiquidiumClient();
       const pools = await client.market.listPools();
-      const dustPool = pools.find((pool) => pool.id === DUST_POOL_ID);
-      const rawPosition = await client.positions.getPosition(
-        DUST_PROFILE_ID,
-        DUST_POOL_ID
+      const positionsByPool = await Promise.all(
+        pools.map(async (pool) => ({
+          pool,
+          position: await client.positions.getPosition(
+            DUST_PROFILE_ID,
+            pool.id
+          ),
+        }))
       );
-      if (!dustPool) {
-        throw new Error(`Dust fixture pool ${DUST_POOL_ID} was not found`);
-      }
-      if (!rawPosition) {
-        throw new Error("Dust fixture position was not found");
+      const dustFixture = positionsByPool.find(
+        ({ pool, position }) =>
+          position !== null &&
+          position.deposited > 0n &&
+          position.borrowed + position.debtInterest > 0n &&
+          position.deposited < pool.sameAssetBorrowingDustThreshold
+      );
+      if (!dustFixture) {
+        const positionSummary = positionsByPool
+          .filter(({ position }) => position !== null)
+          .map(({ pool, position }) => ({
+            asset: pool.asset,
+            poolId: pool.id,
+            deposited: position?.deposited.toString(),
+            borrowed: position?.borrowed.toString(),
+            debtInterest: position?.debtInterest.toString(),
+            dustThreshold: pool.sameAssetBorrowingDustThreshold.toString(),
+          }));
+        throw new Error(
+          `Profile has no dust supply with debt: ${JSON.stringify(positionSummary)}`
+        );
       }
 
       // when
       const visiblePositions =
         await client.positions.listPositions(DUST_PROFILE_ID);
+      const visibleDustPosition = visiblePositions.find(
+        (position) => position.poolId === dustFixture.pool.id
+      );
 
       // then
-      expect(rawPosition.borrowed).toBe(0n);
-      expect(rawPosition.debtInterest).toBe(0n);
-      expect(rawPosition.deposited).toBeLessThan(
-        dustPool.sameAssetBorrowingDustThreshold
+      expect(dustFixture.position?.deposited).toBeLessThan(
+        dustFixture.pool.sameAssetBorrowingDustThreshold
       );
-      expect(
-        visiblePositions.some((position) => position.poolId === DUST_POOL_ID)
-      ).toBe(false);
+      expect(visibleDustPosition?.deposited).toBe(0n);
+      expect(visibleDustPosition?.earnedInterest).toBe(0n);
+      expect(visibleDustPosition?.borrowed).toBeGreaterThanOrEqual(
+        dustFixture.position?.borrowed ?? 0n
+      );
+      expect(visibleDustPosition?.debtInterest).toBeGreaterThanOrEqual(
+        dustFixture.position?.debtInterest ?? 0n
+      );
     }
   );
 });

--- a/e2e/positions.e2e.test.ts
+++ b/e2e/positions.e2e.test.ts
@@ -1,3 +1,8 @@
+// Run this live test with a profile containing a supplied balance below the
+// pool's same-asset dust threshold and outstanding debt in the same pool:
+// LIQUIDIUM_E2E_DUST_PROFILE_ID=<profile-id> LIQUIDIUM_LIVE_E2E=1 \
+//   pnpm exec vitest run --project client-e2e e2e/positions.e2e.test.ts
+
 import { expect, test } from "vitest";
 import { LiquidiumClient } from "../packages/client/src";
 import { describeLive } from "./_internal/live";

--- a/e2e/positions.e2e.test.ts
+++ b/e2e/positions.e2e.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+import { LiquidiumClient } from "../packages/client/src";
+import { describeLive } from "./_internal/live";
+
+const DUST_PROFILE_ID = process.env.LIQUIDIUM_E2E_DUST_PROFILE_ID ?? "";
+const DUST_POOL_ID = process.env.LIQUIDIUM_E2E_DUST_POOL_ID ?? "";
+const HAS_DUST_POSITION_FIXTURE = DUST_PROFILE_ID !== "" && DUST_POOL_ID !== "";
+
+describeLive("live positions e2e", () => {
+  test.skipIf(!HAS_DUST_POSITION_FIXTURE)(
+    "should omit a supplied-only position below its pool dust threshold",
+    async () => {
+      // given
+      const client = new LiquidiumClient();
+      const pools = await client.market.listPools();
+      const dustPool = pools.find((pool) => pool.id === DUST_POOL_ID);
+      const rawPosition = await client.positions.getPosition(
+        DUST_PROFILE_ID,
+        DUST_POOL_ID
+      );
+      if (!dustPool) {
+        throw new Error(`Dust fixture pool ${DUST_POOL_ID} was not found`);
+      }
+      if (!rawPosition) {
+        throw new Error("Dust fixture position was not found");
+      }
+
+      // when
+      const visiblePositions =
+        await client.positions.listPositions(DUST_PROFILE_ID);
+
+      // then
+      expect(rawPosition.borrowed).toBe(0n);
+      expect(rawPosition.debtInterest).toBe(0n);
+      expect(rawPosition.deposited).toBeLessThan(
+        dustPool.sameAssetBorrowingDustThreshold
+      );
+      expect(
+        visiblePositions.some((position) => position.poolId === DUST_POOL_ID)
+      ).toBe(false);
+    }
+  );
+});

--- a/packages/client/src/modules/positions/_internal/positions.test.ts
+++ b/packages/client/src/modules/positions/_internal/positions.test.ts
@@ -11,6 +11,7 @@ afterEach(() => {
 describe("PositionsModule", () => {
   const PROFILE_ID = "aaaaa-aa";
   const POOL_ID = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+  const BTC_DUST_THRESHOLD_SATS = 150n;
 
   function makePositionView(overrides: Record<string, unknown> = {}) {
     return {
@@ -56,6 +57,16 @@ describe("PositionsModule", () => {
         toText: () => PROFILE_ID,
       },
       ...overrides,
+    };
+  }
+
+  function makePoolRecord(
+    poolId = POOL_ID,
+    dustThreshold = BTC_DUST_THRESHOLD_SATS
+  ) {
+    return {
+      principal: { toText: () => poolId },
+      same_asset_borrowing_dust_threshold: dustThreshold,
     };
   }
 
@@ -164,7 +175,7 @@ describe("PositionsModule", () => {
       .fn()
       .mockResolvedValueOnce([
         makePositionView({
-          deposited_native_now: 100n,
+          deposited_native_now: BTC_DUST_THRESHOLD_SATS,
           pool_id: { toText: () => POOL_ID },
         }),
       ])
@@ -179,6 +190,12 @@ describe("PositionsModule", () => {
     vi.spyOn(Actor, "createActor").mockReturnValue({
       get_profile_stats: getProfileStats,
       get_position: getPosition,
+      list_pools: vi
+        .fn()
+        .mockResolvedValue([
+          makePoolRecord(),
+          makePoolRecord(SECOND_POOL_ID, 10_000n),
+        ]),
     } as never);
     const client = new LiquidiumClient({});
 
@@ -190,7 +207,7 @@ describe("PositionsModule", () => {
       {
         poolId: POOL_ID,
         asset: "BTC",
-        deposited: 100n,
+        deposited: BTC_DUST_THRESHOLD_SATS,
         depositedDecimals: 8n,
         borrowed: 0n,
         borrowedDecimals: 8n,
@@ -213,6 +230,67 @@ describe("PositionsModule", () => {
     expect(getPosition).toHaveBeenCalledTimes(2);
   });
 
+  test("filters a supplied-only position below its asset dust threshold", async () => {
+    // given
+    const getProfileStats = vi.fn().mockResolvedValue({
+      debt: 0n,
+      collateral: 0n,
+      acumulated_interest: 0n,
+      borrowing_power: { max_borrowable_usd: 0n, weighted_max_ltv: 0n },
+      positions: [makePositionRecord()],
+      weighted_liquidation_threshold: 0n,
+    });
+    const getPosition = vi.fn().mockResolvedValue([
+      makePositionView({
+        deposited_native_now: BTC_DUST_THRESHOLD_SATS - 1n,
+      }),
+    ]);
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      get_profile_stats: getProfileStats,
+      get_position: getPosition,
+      list_pools: vi.fn().mockResolvedValue([makePoolRecord()]),
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const positions = await client.positions.listPositions(PROFILE_ID);
+
+    // then
+    expect(positions).toEqual([]);
+  });
+
+  test("retains a debt position when its supplied balance is dust", async () => {
+    // given
+    const BORROWED_AMOUNT_SATS = 1n;
+    const getProfileStats = vi.fn().mockResolvedValue({
+      debt: BORROWED_AMOUNT_SATS,
+      collateral: 0n,
+      acumulated_interest: 0n,
+      borrowing_power: { max_borrowable_usd: 0n, weighted_max_ltv: 0n },
+      positions: [makePositionRecord()],
+      weighted_liquidation_threshold: 0n,
+    });
+    const getPosition = vi.fn().mockResolvedValue([
+      makePositionView({
+        deposited_native_now: BTC_DUST_THRESHOLD_SATS - 1n,
+        debt_native_now: BORROWED_AMOUNT_SATS,
+      }),
+    ]);
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      get_profile_stats: getProfileStats,
+      get_position: getPosition,
+      list_pools: vi.fn().mockResolvedValue([makePoolRecord()]),
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const positions = await client.positions.listPositions(PROFILE_ID);
+
+    // then
+    expect(positions).toHaveLength(1);
+    expect(positions[0]?.borrowed).toBe(BORROWED_AMOUNT_SATS);
+  });
+
   test("skips positions that the canister no longer returns in list", async () => {
     // given
     const getProfileStats = vi.fn().mockResolvedValue({
@@ -226,6 +304,7 @@ describe("PositionsModule", () => {
     vi.spyOn(Actor, "createActor").mockReturnValue({
       get_profile_stats: getProfileStats,
       get_position: vi.fn().mockResolvedValue([]),
+      list_pools: vi.fn().mockResolvedValue([makePoolRecord()]),
     } as never);
     const client = new LiquidiumClient({});
 
@@ -679,12 +758,15 @@ describe("PositionsModule", () => {
       ],
       weighted_liquidation_threshold: 0n,
     });
-    const getPosition = vi
-      .fn()
-      .mockResolvedValue([makePositionView({ deposited_native_now: 100n })]);
+    const getPosition = vi.fn().mockResolvedValue([
+      makePositionView({
+        deposited_native_now: BTC_DUST_THRESHOLD_SATS,
+      }),
+    ]);
     vi.spyOn(Actor, "createActor").mockReturnValue({
       get_profile_stats: getProfileStats,
       get_position: getPosition,
+      list_pools: vi.fn().mockResolvedValue([makePoolRecord()]),
     } as never);
     const client = new LiquidiumClient({});
 

--- a/packages/client/src/modules/positions/_internal/positions.test.ts
+++ b/packages/client/src/modules/positions/_internal/positions.test.ts
@@ -262,6 +262,7 @@ describe("PositionsModule", () => {
   test("retains a debt position when its supplied balance is dust", async () => {
     // given
     const BORROWED_AMOUNT_SATS = 1n;
+    const EARNED_INTEREST_SATS = 2n;
     const getProfileStats = vi.fn().mockResolvedValue({
       debt: BORROWED_AMOUNT_SATS,
       collateral: 0n,
@@ -274,6 +275,7 @@ describe("PositionsModule", () => {
       makePositionView({
         deposited_native_now: BTC_DUST_THRESHOLD_SATS - 1n,
         debt_native_now: BORROWED_AMOUNT_SATS,
+        total_earned_interest: EARNED_INTEREST_SATS,
       }),
     ]);
     vi.spyOn(Actor, "createActor").mockReturnValue({
@@ -291,6 +293,80 @@ describe("PositionsModule", () => {
     expect(positions[0]?.deposited).toBe(0n);
     expect(positions[0]?.earnedInterest).toBe(0n);
     expect(positions[0]?.borrowed).toBe(BORROWED_AMOUNT_SATS);
+  });
+
+  test("retains interest-only debt when its supplied balance is dust", async () => {
+    // given
+    const DEBT_INTEREST_SATS = 1n;
+    const getProfileStats = vi.fn().mockResolvedValue({
+      debt: DEBT_INTEREST_SATS,
+      collateral: 0n,
+      acumulated_interest: DEBT_INTEREST_SATS,
+      borrowing_power: { max_borrowable_usd: 0n, weighted_max_ltv: 0n },
+      positions: [makePositionRecord()],
+      weighted_liquidation_threshold: 0n,
+    });
+    const getPosition = vi.fn().mockResolvedValue([
+      makePositionView({
+        deposited_native_now: BTC_DUST_THRESHOLD_SATS - 1n,
+        total_debt_interest: DEBT_INTEREST_SATS,
+      }),
+    ]);
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      get_profile_stats: getProfileStats,
+      get_position: getPosition,
+      list_pools: vi.fn().mockResolvedValue([makePoolRecord()]),
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const positions = await client.positions.listPositions(PROFILE_ID);
+
+    // then
+    expect(positions).toHaveLength(1);
+    expect(positions[0]?.deposited).toBe(0n);
+    expect(positions[0]?.borrowed).toBe(0n);
+    expect(positions[0]?.debtInterest).toBe(DEBT_INTEREST_SATS);
+  });
+
+  test("preserves both supply and debt when supplied balance is not dust", async () => {
+    // given
+    const SUPPLIED_AMOUNT_SATS = BTC_DUST_THRESHOLD_SATS + 1n;
+    const BORROWED_AMOUNT_SATS = 2n;
+    const EARNED_INTEREST_SATS = 3n;
+    const DEBT_INTEREST_SATS = 4n;
+    const getProfileStats = vi.fn().mockResolvedValue({
+      debt: BORROWED_AMOUNT_SATS + DEBT_INTEREST_SATS,
+      collateral: SUPPLIED_AMOUNT_SATS,
+      acumulated_interest: DEBT_INTEREST_SATS,
+      borrowing_power: { max_borrowable_usd: 0n, weighted_max_ltv: 0n },
+      positions: [makePositionRecord()],
+      weighted_liquidation_threshold: 0n,
+    });
+    const getPosition = vi.fn().mockResolvedValue([
+      makePositionView({
+        deposited_native_now: SUPPLIED_AMOUNT_SATS,
+        debt_native_now: BORROWED_AMOUNT_SATS,
+        total_earned_interest: EARNED_INTEREST_SATS,
+        total_debt_interest: DEBT_INTEREST_SATS,
+      }),
+    ]);
+    vi.spyOn(Actor, "createActor").mockReturnValue({
+      get_profile_stats: getProfileStats,
+      get_position: getPosition,
+      list_pools: vi.fn().mockResolvedValue([makePoolRecord()]),
+    } as never);
+    const client = new LiquidiumClient({});
+
+    // when
+    const positions = await client.positions.listPositions(PROFILE_ID);
+
+    // then
+    expect(positions).toHaveLength(1);
+    expect(positions[0]?.deposited).toBe(SUPPLIED_AMOUNT_SATS);
+    expect(positions[0]?.earnedInterest).toBe(EARNED_INTEREST_SATS);
+    expect(positions[0]?.borrowed).toBe(BORROWED_AMOUNT_SATS);
+    expect(positions[0]?.debtInterest).toBe(DEBT_INTEREST_SATS);
   });
 
   test("skips positions that the canister no longer returns in list", async () => {

--- a/packages/client/src/modules/positions/_internal/positions.test.ts
+++ b/packages/client/src/modules/positions/_internal/positions.test.ts
@@ -288,6 +288,8 @@ describe("PositionsModule", () => {
 
     // then
     expect(positions).toHaveLength(1);
+    expect(positions[0]?.deposited).toBe(0n);
+    expect(positions[0]?.earnedInterest).toBe(0n);
     expect(positions[0]?.borrowed).toBe(BORROWED_AMOUNT_SATS);
   });
 

--- a/packages/client/src/modules/positions/positions.ts
+++ b/packages/client/src/modules/positions/positions.ts
@@ -212,6 +212,10 @@ export class PositionsModule {
    * Returns the per-reserve breakdown of a profile's supplies and borrows,
    * joined with pool metadata, rates, and current USD prices.
    *
+   * Supplied-only reserves below their pool's same-asset dust threshold are
+   * omitted. Reserves with active debt remain, with their supplied amount and
+   * earned interest set to zero when the supplied balance is below the threshold.
+   *
    * USD values are scaled to 27 decimals.
    *
    * @param profileId - The Liquidium profile principal text.

--- a/packages/client/src/modules/positions/positions.ts
+++ b/packages/client/src/modules/positions/positions.ts
@@ -105,12 +105,13 @@ export class PositionsModule {
         .map(decodeFlexiblePositionView)
         .filter((view): view is NonNullable<typeof view> => view !== null)
         .map(mapDecodedPositionViewToPosition)
-        .flatMap((position) =>
-          hideSuppliedPositionDust(
+        .map((position) =>
+          getPositionWithSuppliedDustHidden(
             position,
             dustThresholdsByPoolId.get(position.poolId)
           )
-        );
+        )
+        .filter((position): position is Position => position !== null);
     } catch (error) {
       if (error instanceof LiquidiumError) {
         throw error;
@@ -309,20 +310,21 @@ export class PositionsModule {
   }
 }
 
-function hideSuppliedPositionDust(
+/** Drops dust-only positions and clears the supply side when debt remains. */
+function getPositionWithSuppliedDustHidden(
   position: Position,
   dustThreshold: bigint | undefined
-): Position[] {
+): Position | null {
   if (dustThreshold === undefined || position.deposited >= dustThreshold) {
-    return [position];
+    return position;
   }
 
   const hasDebt = position.borrowed > 0n || position.debtInterest > 0n;
   if (!hasDebt) {
-    return [];
+    return null;
   }
 
-  return [{ ...position, deposited: 0n, earnedInterest: 0n }];
+  return { ...position, deposited: 0n, earnedInterest: 0n };
 }
 
 function nativeAmountToUsdScaled(

--- a/packages/client/src/modules/positions/positions.ts
+++ b/packages/client/src/modules/positions/positions.ts
@@ -71,17 +71,28 @@ export class PositionsModule {
   }
 
   /**
-   * Lists all positions for a profile.
+   * Lists visible positions for a profile. Supplied-only positions below their
+   * pool's same-asset dust threshold are omitted, while positions with debt are
+   * retained.
    *
    * @param profileId - The Liquidium profile principal text.
-   * @returns All positions currently associated with the requested profile.
+   * @returns Visible positions currently associated with the requested profile.
    */
   async listPositions(profileId: string): Promise<Position[]> {
     try {
       const actor = createFlexibleLendingActor(this.canisterContext);
       const profilePrincipal = Principal.fromText(profileId);
-      const stats = await actor.get_profile_stats(profilePrincipal);
+      const [stats, pools] = await Promise.all([
+        actor.get_profile_stats(profilePrincipal),
+        actor.list_pools(),
+      ]);
       const decodedStats = decodeFlexibleUserStats(stats);
+      const dustThresholdsByPoolId = new Map(
+        pools.map((pool) => [
+          pool.principal.toText(),
+          pool.same_asset_borrowing_dust_threshold,
+        ])
+      );
 
       const positionViews = await Promise.all(
         decodedStats.positions.map((position) =>
@@ -94,7 +105,14 @@ export class PositionsModule {
         .filter((view): view is NonNullable<typeof view> => view !== undefined)
         .map(decodeFlexiblePositionView)
         .filter((view): view is NonNullable<typeof view> => view !== null)
-        .map(mapDecodedPositionViewToPosition);
+        .map(mapDecodedPositionViewToPosition)
+        .filter(
+          (position) =>
+            !isSuppliedPositionDust(
+              position,
+              dustThresholdsByPoolId.get(position.poolId)
+            )
+        );
     } catch (error) {
       if (error instanceof LiquidiumError) {
         throw error;
@@ -291,6 +309,18 @@ export class PositionsModule {
 
     return { amount: position.deposited, decimals: position.depositedDecimals };
   }
+}
+
+function isSuppliedPositionDust(
+  position: Position,
+  dustThreshold: bigint | undefined
+): boolean {
+  const hasDebt = position.borrowed > 0n || position.debtInterest > 0n;
+  if (hasDebt || dustThreshold === undefined) {
+    return false;
+  }
+
+  return position.deposited < dustThreshold;
 }
 
 function nativeAmountToUsdScaled(

--- a/packages/client/src/modules/positions/positions.ts
+++ b/packages/client/src/modules/positions/positions.ts
@@ -71,9 +71,8 @@ export class PositionsModule {
   }
 
   /**
-   * Lists visible positions for a profile. Supplied-only positions below their
-   * pool's same-asset dust threshold are omitted, while positions with debt are
-   * retained.
+   * Lists visible positions for a profile. Supply balances below their pool's
+   * same-asset dust threshold are hidden without removing active debt.
    *
    * @param profileId - The Liquidium profile principal text.
    * @returns Visible positions currently associated with the requested profile.
@@ -106,12 +105,11 @@ export class PositionsModule {
         .map(decodeFlexiblePositionView)
         .filter((view): view is NonNullable<typeof view> => view !== null)
         .map(mapDecodedPositionViewToPosition)
-        .filter(
-          (position) =>
-            !isSuppliedPositionDust(
-              position,
-              dustThresholdsByPoolId.get(position.poolId)
-            )
+        .flatMap((position) =>
+          hideSuppliedPositionDust(
+            position,
+            dustThresholdsByPoolId.get(position.poolId)
+          )
         );
     } catch (error) {
       if (error instanceof LiquidiumError) {
@@ -311,16 +309,20 @@ export class PositionsModule {
   }
 }
 
-function isSuppliedPositionDust(
+function hideSuppliedPositionDust(
   position: Position,
   dustThreshold: bigint | undefined
-): boolean {
-  const hasDebt = position.borrowed > 0n || position.debtInterest > 0n;
-  if (hasDebt || dustThreshold === undefined) {
-    return false;
+): Position[] {
+  if (dustThreshold === undefined || position.deposited >= dustThreshold) {
+    return [position];
   }
 
-  return position.deposited < dustThreshold;
+  const hasDebt = position.borrowed > 0n || position.debtInterest > 0n;
+  if (!hasDebt) {
+    return [];
+  }
+
+  return [{ ...position, deposited: 0n, earnedInterest: 0n }];
 }
 
 function nativeAmountToUsdScaled(

--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -301,6 +301,11 @@ client.positions.getMaxRepayAmount(profileId, poolId, bufferBps?); // full-repay
 client.positions.getFullWithdrawAmount(profileId, poolId);         // current supplied balance for full withdraw
 ```
 
+`listPositions(...)` and `getUserReserves(...)` omit supplied-only balances
+below each pool's `sameAssetBorrowingDustThreshold`. Positions containing debt
+are always returned, even when their supplied balance is dust. Use
+`getPosition(...)` when the raw position for a specific pool is required.
+
 `getFullWithdrawAmount(...)` returns `{ amount, decimals }`. Pass `amount` to
 `client.lending.withdraw(...)` or `prepareWithdraw(...)`; use `decimals` only
 for UI formatting. Do not add `earnedInterest` to the returned amount.

--- a/skills/liquidium-sdk-integration/SKILL.md
+++ b/skills/liquidium-sdk-integration/SKILL.md
@@ -302,9 +302,9 @@ client.positions.getFullWithdrawAmount(profileId, poolId);         // current su
 ```
 
 `listPositions(...)` and `getUserReserves(...)` omit supplied-only balances
-below each pool's `sameAssetBorrowingDustThreshold`. Positions containing debt
-are always returned, even when their supplied balance is dust. Use
-`getPosition(...)` when the raw position for a specific pool is required.
+below each pool's `sameAssetBorrowingDustThreshold`. When the same position has
+debt, it remains in the result with its supplied balance and earned interest set
+to zero. Use `getPosition(...)` when the raw position is required.
 
 `getFullWithdrawAmount(...)` returns `{ amount, decimals }`. Pass `amount` to
 `client.lending.withdraw(...)` or `prepareWithdraw(...)`; use `decimals` only


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `listPositions` reporting by hiding supplied-only balances below each pool’s `sameAssetBorrowingDustThreshold`.
  * Kept positions that have active debt even when supplied amounts are dust (with supplied/earned interest cleared accordingly).
  * Applied pool-specific dust thresholds consistently across position decoding and reserve behavior.

* **Documentation**
  * Updated positions/reserves API docs to describe dust filtering and the debt-retention behavior.
  * Clarified that raw per-pool details can be retrieved via `getPosition(...)`.

* **Tests**
  * Expanded position filtering coverage with additional E2E and unit test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->