### PR TITLE
chore(client): prepare 0.5.2 release

### DIFF
--- a/.changeset/hide-supplied-position-dust.md
+++ b/.changeset/hide-supplied-position-dust.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": patch
----
-
-Hide supplied balances below each pool's dust threshold while preserving positions with active debt.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,12 @@ Released changes for `@liquidium/client`. This page is generated from [`packages
 
 ## @liquidium/client
 
+### 0.5.2
+
+#### Patch Changes
+
+- 32d391f: Hide supplied balances below each pool's dust threshold while preserving positions with active debt.
+
 ### 0.5.1
 
 #### Patch Changes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @liquidium/client
 
+## 0.5.2
+
+### Patch Changes
+
+- 32d391f: Hide supplied balances below each pool's dust threshold while preserving positions with active debt.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquidium/client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "The official client for the Liquidium protocol",
   "keywords": [
     "liquidium",


### PR DESCRIPTION
Prepare @liquidium/client 0.5.2 from the merged patch changeset.\n\nChecks: pnpm lint, pnpm build, pnpm typecheck, pnpm test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Supplied balances below each pool’s dust threshold are now hidden from display.
  - Positions with active debt continue to be shown accurately.

- **Release**
  - Updated `@liquidium/client` to version 0.5.2.

- **Documentation**
  - Added release notes describing the balance-display adjustment and debt-position handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->