### PR TITLE
chore(client): prepare 0.7.0 release

### DIFF
--- a/.changeset/bright-rates-compound.md
+++ b/.changeset/bright-rates-compound.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Expose estimated borrow and supply APYs for current pool rates.

--- a/.changeset/fresh-prices-arrive.md
+++ b/.changeset/fresh-prices-arrive.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Add price snapshots with an explicit SDK fetch timestamp.

--- a/.changeset/green-assets-shine.md
+++ b/.changeset/green-assets-shine.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Add stable display names for supported assets.

--- a/.changeset/honest-health-factors.md
+++ b/.changeset/honest-health-factors.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Expose the health-factor scale and return null for no-debt health factors.

--- a/.changeset/known-profiles-exist.md
+++ b/.changeset/known-profiles-exist.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Add an account helper for distinguishing registered profiles from unknown IDs.

--- a/.changeset/soft-cats-report.md
+++ b/.changeset/soft-cats-report.md
@@ -1,6 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Add the protocol-wide activity history feed backed by
-`GET /v2/history/activities`.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,18 @@ Released changes for `@liquidium/client`. This page is generated from [`packages
 
 ## @liquidium/client
 
+### 0.7.0
+
+#### Minor Changes
+
+- 8ed003f: Expose estimated borrow and supply APYs for current pool rates.
+- 8ed003f: Add price snapshots with an explicit SDK fetch timestamp.
+- 8ed003f: Add stable display names for supported assets.
+- 8ed003f: Expose the health-factor scale and return null for no-debt health factors.
+- 8ed003f: Add an account helper for distinguishing registered profiles from unknown IDs.
+- d38dc31: Add the protocol-wide activity history feed backed by
+  `GET /v2/history/activities`.
+
 ### 0.6.0
 
 #### Minor Changes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @liquidium/client
 
+## 0.7.0
+
+### Minor Changes
+
+- 8ed003f: Expose estimated borrow and supply APYs for current pool rates.
+- 8ed003f: Add price snapshots with an explicit SDK fetch timestamp.
+- 8ed003f: Add stable display names for supported assets.
+- 8ed003f: Expose the health-factor scale and return null for no-debt health factors.
+- 8ed003f: Add an account helper for distinguishing registered profiles from unknown IDs.
+- d38dc31: Add the protocol-wide activity history feed backed by
+  `GET /v2/history/activities`.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquidium/client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The official client for the Liquidium protocol",
   "keywords": [
     "liquidium",


### PR DESCRIPTION
## Summary

- bump `@liquidium/client` from 0.6.0 to 0.7.0
- generate the package and docs changelogs
- consume the six included minor changesets

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`