### PR TITLE
chore(client): prepare 0.7.1 release

### DIFF
--- a/.changeset/quiet-wallets-check.md
+++ b/.changeset/quiet-wallets-check.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": patch
----
-
-Reject reserved Ethereum destinations and best-effort block native ETH addresses with deployed code.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,12 @@ Released changes for `@liquidium/client`. This page is generated from [`packages
 
 ## @liquidium/client
 
+### 0.7.1
+
+#### Patch Changes
+
+- 033f016: Reject reserved Ethereum destinations and best-effort block native ETH addresses with deployed code.
+
 ### 0.7.0
 
 #### Minor Changes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @liquidium/client
 
+## 0.7.1
+
+### Patch Changes
+
+- 033f016: Reject reserved Ethereum destinations and best-effort block native ETH addresses with deployed code.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquidium/client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The official client for the Liquidium protocol",
   "keywords": [
     "liquidium",


### PR DESCRIPTION
Publishes the smart-wallet outflow validation fix as @liquidium/client 0.7.1.\n\nChecks: pnpm lint, pnpm build, pnpm typecheck, pnpm test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the `@liquidium/client` 0.7.1 release.
  * Added notes on rejecting reserved Ethereum destinations and native ETH addresses containing deployed code.

* **Chores**
  * Updated the `@liquidium/client` version from 0.7.0 to 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->