### PR TITLE
chore(client): prepare 0.8.0 release

### DIFF
--- a/.changeset/fresh-agents-connect.md
+++ b/.changeset/fresh-agents-connect.md
@@ -1,5 +1,0 @@
----
-"@liquidium/client": minor
----
-
-Allow callers to provide a preconfigured ICP agent through `LiquidiumClientConfig.agent`.

--- a/docs/api-reference/generated/functions/isAssetIdentifier.md
+++ b/docs/api-reference/generated/functions/isAssetIdentifier.md
@@ -8,7 +8,7 @@
 
 > **isAssetIdentifier**(`identifier`): `identifier is AssetIdentifier`
 
-Defined in: [packages/client/src/core/types.ts:181](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L181)
+Defined in: [packages/client/src/core/types.ts:183](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L183)
 
 Returns whether an asset and chain form a supported SDK identifier.
 

--- a/docs/api-reference/generated/interfaces/BtcOnBtcAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/BtcOnBtcAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: BtcOnBtcAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:115](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L115)
+Defined in: [packages/client/src/core/types.ts:117](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L117)
 
 BTC transferred on the Bitcoin chain.
 
@@ -16,7 +16,7 @@ BTC transferred on the Bitcoin chain.
 
 > **asset**: `"BTC"`
 
-Defined in: [packages/client/src/core/types.ts:117](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L117)
+Defined in: [packages/client/src/core/types.ts:119](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L119)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:117](https://github.com/Liquidium
 
 > **chain**: `"BTC"`
 
-Defined in: [packages/client/src/core/types.ts:116](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L116)
+Defined in: [packages/client/src/core/types.ts:118](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L118)

--- a/docs/api-reference/generated/interfaces/BtcOnIcpAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/BtcOnIcpAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: BtcOnIcpAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:139](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L139)
+Defined in: [packages/client/src/core/types.ts:141](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L141)
 
 BTC transferred on the Internet Computer chain.
 
@@ -16,7 +16,7 @@ BTC transferred on the Internet Computer chain.
 
 > **asset**: `"BTC"`
 
-Defined in: [packages/client/src/core/types.ts:141](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L141)
+Defined in: [packages/client/src/core/types.ts:143](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L143)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:141](https://github.com/Liquidium
 
 > **chain**: `"ICP"`
 
-Defined in: [packages/client/src/core/types.ts:140](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L140)
+Defined in: [packages/client/src/core/types.ts:142](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L142)

--- a/docs/api-reference/generated/interfaces/CanisterIds.md
+++ b/docs/api-reference/generated/interfaces/CanisterIds.md
@@ -6,7 +6,7 @@
 
 # Interface: CanisterIds
 
-Defined in: [packages/client/src/core/types.ts:67](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L67)
+Defined in: [packages/client/src/core/types.ts:69](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L69)
 
 Principal text values for canisters used by the client.
 
@@ -16,7 +16,7 @@ Principal text values for canisters used by the client.
 
 > **ethDeposit**: `string`
 
-Defined in: [packages/client/src/core/types.ts:73](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L73)
+Defined in: [packages/client/src/core/types.ts:75](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L75)
 
 ckETH minter deposit helper canister principal.
 
@@ -26,7 +26,7 @@ ckETH minter deposit helper canister principal.
 
 > **lending**: `string`
 
-Defined in: [packages/client/src/core/types.ts:69](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L69)
+Defined in: [packages/client/src/core/types.ts:71](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L71)
 
 Liquidium lending canister principal.
 
@@ -36,7 +36,7 @@ Liquidium lending canister principal.
 
 > **pools**: [`PoolCanisterIds`](PoolCanisterIds.md)
 
-Defined in: [packages/client/src/core/types.ts:71](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L71)
+Defined in: [packages/client/src/core/types.ts:73](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L73)
 
 Pool canister principals grouped by pool asset.
 
@@ -46,6 +46,6 @@ Pool canister principals grouped by pool asset.
 
 > **simpleLoans**: `string`
 
-Defined in: [packages/client/src/core/types.ts:75](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L75)
+Defined in: [packages/client/src/core/types.ts:77](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L77)
 
 Accountless Simple Loans canister principal.

--- a/docs/api-reference/generated/interfaces/EthOnEthAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/EthOnEthAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: EthOnEthAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:121](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L121)
+Defined in: [packages/client/src/core/types.ts:123](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L123)
 
 ETH transferred on the Ethereum chain.
 
@@ -16,7 +16,7 @@ ETH transferred on the Ethereum chain.
 
 > **asset**: `"ETH"`
 
-Defined in: [packages/client/src/core/types.ts:123](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L123)
+Defined in: [packages/client/src/core/types.ts:125](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L125)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:123](https://github.com/Liquidium
 
 > **chain**: `"ETH"`
 
-Defined in: [packages/client/src/core/types.ts:122](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L122)
+Defined in: [packages/client/src/core/types.ts:124](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L124)

--- a/docs/api-reference/generated/interfaces/EthOnIcpAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/EthOnIcpAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: EthOnIcpAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:145](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L145)
+Defined in: [packages/client/src/core/types.ts:147](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L147)
 
 ETH transferred on the Internet Computer chain.
 
@@ -16,7 +16,7 @@ ETH transferred on the Internet Computer chain.
 
 > **asset**: `"ETH"`
 
-Defined in: [packages/client/src/core/types.ts:147](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L147)
+Defined in: [packages/client/src/core/types.ts:149](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L149)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:147](https://github.com/Liquidium
 
 > **chain**: `"ICP"`
 
-Defined in: [packages/client/src/core/types.ts:146](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L146)
+Defined in: [packages/client/src/core/types.ts:148](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L148)

--- a/docs/api-reference/generated/interfaces/IcpOnIcpAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/IcpOnIcpAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: IcpOnIcpAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:151](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L151)
+Defined in: [packages/client/src/core/types.ts:153](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L153)
 
 ICP transferred on the Internet Computer chain.
 
@@ -16,7 +16,7 @@ ICP transferred on the Internet Computer chain.
 
 > **asset**: `"ICP"`
 
-Defined in: [packages/client/src/core/types.ts:153](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L153)
+Defined in: [packages/client/src/core/types.ts:155](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L155)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:153](https://github.com/Liquidium
 
 > **chain**: `"ICP"`
 
-Defined in: [packages/client/src/core/types.ts:152](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L152)
+Defined in: [packages/client/src/core/types.ts:154](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L154)

--- a/docs/api-reference/generated/interfaces/LiquidiumClientConfig.md
+++ b/docs/api-reference/generated/interfaces/LiquidiumClientConfig.md
@@ -15,11 +15,21 @@ Canister-backed reads and SDK HTTP features work with `{}` defaults. Set
 
 ## Properties
 
+### agent?
+
+> `optional` **agent?**: `Agent`
+
+Defined in: [packages/client/src/core/types.ts:27](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L27)
+
+Preconfigured ICP agent. Takes precedence over `icHost` and `identity`.
+
+***
+
 ### apiBaseUrl?
 
 > `optional` **apiBaseUrl?**: `string`
 
-Defined in: [packages/client/src/core/types.ts:35](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L35)
+Defined in: [packages/client/src/core/types.ts:37](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L37)
 
 Base URL for the Liquidium SDK HTTP API root (e.g. `https://app.example.com/api/sdk`).
 Defaults to the Liquidium production API root. Endpoint versions are owned
@@ -31,7 +41,7 @@ by this SDK package version.
 
 > `optional` **canisterIds?**: [`CanisterIdOverrides`](../type-aliases/CanisterIdOverrides.md)
 
-Defined in: [packages/client/src/core/types.ts:39](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L39)
+Defined in: [packages/client/src/core/types.ts:41](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L41)
 
 Override individual canister principals for custom deployments.
 
@@ -51,7 +61,7 @@ Preset canister IDs. Only `mainnet` is bundled.
 
 > `optional` **evmPublicClient?**: [`EvmReadClient`](EvmReadClient.md)
 
-Defined in: [packages/client/src/core/types.ts:49](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L49)
+Defined in: [packages/client/src/core/types.ts:51](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L51)
 
 Existing viem client; mainnet `chain` and `getCode` enable native ETH outflow checks.
 
@@ -61,7 +71,7 @@ Existing viem client; mainnet `chain` and `getCode` enable native ETH outflow ch
 
 > `optional` **evmRpcHeaders?**: `Record`\<`string`, `string`\>
 
-Defined in: [packages/client/src/core/types.ts:47](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L47)
+Defined in: [packages/client/src/core/types.ts:49](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L49)
 
 Optional headers for RPC providers that authenticate via HTTP headers.
 
@@ -71,7 +81,7 @@ Optional headers for RPC providers that authenticate via HTTP headers.
 
 > `optional` **evmRpcUrl?**: `string`
 
-Defined in: [packages/client/src/core/types.ts:45](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L45)
+Defined in: [packages/client/src/core/types.ts:47](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L47)
 
 Ethereum RPC URL used for best-effort native ETH outflow checks and public ERC-20 reads.
 
@@ -81,7 +91,7 @@ Ethereum RPC URL used for best-effort native ETH outflow checks and public ERC-2
 
 > `optional` **fetch?**: \{(`input`, `init?`): `Promise`\<`Response`\>; (`input`, `init?`): `Promise`\<`Response`\>; \}
 
-Defined in: [packages/client/src/core/types.ts:41](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L41)
+Defined in: [packages/client/src/core/types.ts:43](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L43)
 
 Custom `fetch` implementation for SDK API requests.
 
@@ -131,7 +141,7 @@ Custom `fetch` implementation for SDK API requests.
 
 > `optional` **headers?**: `Record`\<`string`, `string`\>
 
-Defined in: [packages/client/src/core/types.ts:37](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L37)
+Defined in: [packages/client/src/core/types.ts:39](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L39)
 
 Extra headers sent with every SDK API request.
 
@@ -141,7 +151,7 @@ Extra headers sent with every SDK API request.
 
 > `optional` **icHost?**: `string`
 
-Defined in: [packages/client/src/core/types.ts:27](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L27)
+Defined in: [packages/client/src/core/types.ts:29](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L29)
 
 ICP replica host override (defaults follow `@icp-sdk/core/agent`).
 
@@ -151,7 +161,7 @@ ICP replica host override (defaults follow `@icp-sdk/core/agent`).
 
 > `optional` **identity?**: `Identity`
 
-Defined in: [packages/client/src/core/types.ts:29](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L29)
+Defined in: [packages/client/src/core/types.ts:31](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L31)
 
 Agent identity for signed canister calls.
 
@@ -161,6 +171,6 @@ Agent identity for signed canister calls.
 
 > `optional` **timeoutMs?**: `number`
 
-Defined in: [packages/client/src/core/types.ts:43](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L43)
+Defined in: [packages/client/src/core/types.ts:45](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L45)
 
 Per-request timeout for SDK API calls in milliseconds.

--- a/docs/api-reference/generated/interfaces/PoolCanisterIds.md
+++ b/docs/api-reference/generated/interfaces/PoolCanisterIds.md
@@ -6,7 +6,7 @@
 
 # Interface: PoolCanisterIds
 
-Defined in: [packages/client/src/core/types.ts:53](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L53)
+Defined in: [packages/client/src/core/types.ts:55](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L55)
 
 Pool canister principal text values grouped by pool asset.
 
@@ -16,7 +16,7 @@ Pool canister principal text values grouped by pool asset.
 
 > **btc**: `string`
 
-Defined in: [packages/client/src/core/types.ts:55](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L55)
+Defined in: [packages/client/src/core/types.ts:57](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L57)
 
 BTC pool canister principal.
 
@@ -26,7 +26,7 @@ BTC pool canister principal.
 
 > **eth**: `string`
 
-Defined in: [packages/client/src/core/types.ts:57](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L57)
+Defined in: [packages/client/src/core/types.ts:59](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L59)
 
 ETH pool canister principal.
 
@@ -36,7 +36,7 @@ ETH pool canister principal.
 
 > **icp**: `string`
 
-Defined in: [packages/client/src/core/types.ts:63](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L63)
+Defined in: [packages/client/src/core/types.ts:65](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L65)
 
 ICP pool canister principal.
 
@@ -46,7 +46,7 @@ ICP pool canister principal.
 
 > **usdc**: `string`
 
-Defined in: [packages/client/src/core/types.ts:61](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L61)
+Defined in: [packages/client/src/core/types.ts:63](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L63)
 
 USDC pool canister principal.
 
@@ -56,6 +56,6 @@ USDC pool canister principal.
 
 > **usdt**: `string`
 
-Defined in: [packages/client/src/core/types.ts:59](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L59)
+Defined in: [packages/client/src/core/types.ts:61](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L61)
 
 USDT pool canister principal.

--- a/docs/api-reference/generated/interfaces/UsdcOnEthAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/UsdcOnEthAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: UsdcOnEthAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:127](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L127)
+Defined in: [packages/client/src/core/types.ts:129](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L129)
 
 USDC transferred on the Ethereum chain.
 
@@ -16,7 +16,7 @@ USDC transferred on the Ethereum chain.
 
 > **asset**: `"USDC"`
 
-Defined in: [packages/client/src/core/types.ts:129](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L129)
+Defined in: [packages/client/src/core/types.ts:131](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L131)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:129](https://github.com/Liquidium
 
 > **chain**: `"ETH"`
 
-Defined in: [packages/client/src/core/types.ts:128](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L128)
+Defined in: [packages/client/src/core/types.ts:130](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L130)

--- a/docs/api-reference/generated/interfaces/UsdcOnIcpAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/UsdcOnIcpAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: UsdcOnIcpAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:157](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L157)
+Defined in: [packages/client/src/core/types.ts:159](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L159)
 
 USDC transferred on the Internet Computer chain.
 
@@ -16,7 +16,7 @@ USDC transferred on the Internet Computer chain.
 
 > **asset**: `"USDC"`
 
-Defined in: [packages/client/src/core/types.ts:159](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L159)
+Defined in: [packages/client/src/core/types.ts:161](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L161)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:159](https://github.com/Liquidium
 
 > **chain**: `"ICP"`
 
-Defined in: [packages/client/src/core/types.ts:158](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L158)
+Defined in: [packages/client/src/core/types.ts:160](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L160)

--- a/docs/api-reference/generated/interfaces/UsdtOnEthAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/UsdtOnEthAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: UsdtOnEthAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:133](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L133)
+Defined in: [packages/client/src/core/types.ts:135](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L135)
 
 USDT transferred on the Ethereum chain.
 
@@ -16,7 +16,7 @@ USDT transferred on the Ethereum chain.
 
 > **asset**: `"USDT"`
 
-Defined in: [packages/client/src/core/types.ts:135](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L135)
+Defined in: [packages/client/src/core/types.ts:137](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L137)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:135](https://github.com/Liquidium
 
 > **chain**: `"ETH"`
 
-Defined in: [packages/client/src/core/types.ts:134](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L134)
+Defined in: [packages/client/src/core/types.ts:136](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L136)

--- a/docs/api-reference/generated/interfaces/UsdtOnIcpAssetIdentifier.md
+++ b/docs/api-reference/generated/interfaces/UsdtOnIcpAssetIdentifier.md
@@ -6,7 +6,7 @@
 
 # Interface: UsdtOnIcpAssetIdentifier
 
-Defined in: [packages/client/src/core/types.ts:163](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L163)
+Defined in: [packages/client/src/core/types.ts:165](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L165)
 
 USDT transferred on the Internet Computer chain.
 
@@ -16,7 +16,7 @@ USDT transferred on the Internet Computer chain.
 
 > **asset**: `"USDT"`
 
-Defined in: [packages/client/src/core/types.ts:165](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L165)
+Defined in: [packages/client/src/core/types.ts:167](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L167)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [packages/client/src/core/types.ts:165](https://github.com/Liquidium
 
 > **chain**: `"ICP"`
 
-Defined in: [packages/client/src/core/types.ts:164](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L164)
+Defined in: [packages/client/src/core/types.ts:166](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L166)

--- a/docs/api-reference/generated/interfaces/Wallet.md
+++ b/docs/api-reference/generated/interfaces/Wallet.md
@@ -6,7 +6,7 @@
 
 # Interface: Wallet
 
-Defined in: [packages/client/src/core/types.ts:225](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L225)
+Defined in: [packages/client/src/core/types.ts:227](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L227)
 
 Wallet address and chain pair linked to a Liquidium profile.
 
@@ -16,7 +16,7 @@ Wallet address and chain pair linked to a Liquidium profile.
 
 > **address**: `string`
 
-Defined in: [packages/client/src/core/types.ts:229](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L229)
+Defined in: [packages/client/src/core/types.ts:231](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L231)
 
 Wallet address as stored by the protocol.
 
@@ -26,6 +26,6 @@ Wallet address as stored by the protocol.
 
 > **chain**: [`SigningChain`](../type-aliases/SigningChain.md)
 
-Defined in: [packages/client/src/core/types.ts:227](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L227)
+Defined in: [packages/client/src/core/types.ts:229](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L229)
 
 Chain where the wallet address is valid.

--- a/docs/api-reference/generated/type-aliases/Asset.md
+++ b/docs/api-reference/generated/type-aliases/Asset.md
@@ -8,6 +8,6 @@
 
 > **Asset** = *typeof* [`Asset`](../variables/Asset.md)\[keyof *typeof* [`Asset`](../variables/Asset.md)\]
 
-Defined in: [packages/client/src/core/types.ts:92](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L92)
+Defined in: [packages/client/src/core/types.ts:94](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L94)
 
 Canonical asset symbol supported by state-mutating protocol flows.

--- a/docs/api-reference/generated/type-aliases/AssetIdentifier.md
+++ b/docs/api-reference/generated/type-aliases/AssetIdentifier.md
@@ -8,6 +8,6 @@
 
 > **AssetIdentifier** = [`BtcOnBtcAssetIdentifier`](../interfaces/BtcOnBtcAssetIdentifier.md) \| [`EthOnEthAssetIdentifier`](../interfaces/EthOnEthAssetIdentifier.md) \| [`UsdcOnEthAssetIdentifier`](../interfaces/UsdcOnEthAssetIdentifier.md) \| [`UsdtOnEthAssetIdentifier`](../interfaces/UsdtOnEthAssetIdentifier.md) \| [`BtcOnIcpAssetIdentifier`](../interfaces/BtcOnIcpAssetIdentifier.md) \| [`EthOnIcpAssetIdentifier`](../interfaces/EthOnIcpAssetIdentifier.md) \| [`IcpOnIcpAssetIdentifier`](../interfaces/IcpOnIcpAssetIdentifier.md) \| [`UsdcOnIcpAssetIdentifier`](../interfaces/UsdcOnIcpAssetIdentifier.md) \| [`UsdtOnIcpAssetIdentifier`](../interfaces/UsdtOnIcpAssetIdentifier.md)
 
-Defined in: [packages/client/src/core/types.ts:169](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L169)
+Defined in: [packages/client/src/core/types.ts:171](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L171)
 
 Supported asset and transfer-chain combinations.

--- a/docs/api-reference/generated/type-aliases/CanisterIdOverrides.md
+++ b/docs/api-reference/generated/type-aliases/CanisterIdOverrides.md
@@ -8,7 +8,7 @@
 
 > **CanisterIdOverrides** = `Omit`\<`Partial`\<[`CanisterIds`](../interfaces/CanisterIds.md)\>, `"pools"`\> & `object`
 
-Defined in: [packages/client/src/core/types.ts:79](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L79)
+Defined in: [packages/client/src/core/types.ts:81](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L81)
 
 Custom canister principal overrides accepted by client configuration.
 

--- a/docs/api-reference/generated/type-aliases/Chain.md
+++ b/docs/api-reference/generated/type-aliases/Chain.md
@@ -8,6 +8,6 @@
 
 > **Chain** = *typeof* [`Chain`](../variables/Chain.md)\[keyof *typeof* [`Chain`](../variables/Chain.md)\]
 
-Defined in: [packages/client/src/core/types.ts:103](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L103)
+Defined in: [packages/client/src/core/types.ts:105](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L105)
 
 Canonical chain identifier used by wallet and protocol actions.

--- a/docs/api-reference/generated/type-aliases/Environment.md
+++ b/docs/api-reference/generated/type-aliases/Environment.md
@@ -8,6 +8,6 @@
 
 > **Environment** = *typeof* [`Environment`](../variables/Environment.md)\[keyof *typeof* [`Environment`](../variables/Environment.md)\]
 
-Defined in: [packages/client/src/core/types.ts:85](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L85)
+Defined in: [packages/client/src/core/types.ts:87](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L87)
 
 Supported deployment environment name.

--- a/docs/api-reference/generated/type-aliases/OutflowType.md
+++ b/docs/api-reference/generated/type-aliases/OutflowType.md
@@ -8,6 +8,6 @@
 
 > **OutflowType** = *typeof* [`OutflowType`](../variables/OutflowType.md)\[keyof *typeof* [`OutflowType`](../variables/OutflowType.md)\]
 
-Defined in: [packages/client/src/core/types.ts:216](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L216)
+Defined in: [packages/client/src/core/types.ts:218](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L218)
 
 Outflow operation reported by the lending canister.

--- a/docs/api-reference/generated/type-aliases/SigningChain.md
+++ b/docs/api-reference/generated/type-aliases/SigningChain.md
@@ -8,6 +8,6 @@
 
 > **SigningChain** = *typeof* [`BTC`](../variables/Chain.md#btc) \| *typeof* [`ETH`](../variables/Chain.md#eth)
 
-Defined in: [packages/client/src/core/types.ts:112](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L112)
+Defined in: [packages/client/src/core/types.ts:114](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L114)
 
 Chains whose wallets can authorize Liquidium protocol actions.

--- a/docs/api-reference/generated/type-aliases/SupplyAction.md
+++ b/docs/api-reference/generated/type-aliases/SupplyAction.md
@@ -8,6 +8,6 @@
 
 > **SupplyAction** = *typeof* [`SupplyAction`](../variables/SupplyAction.md)\[keyof *typeof* [`SupplyAction`](../variables/SupplyAction.md)\]
 
-Defined in: [packages/client/src/core/types.ts:208](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L208)
+Defined in: [packages/client/src/core/types.ts:210](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L210)
 
 Inflow operation performed by a supply target.

--- a/docs/api-reference/generated/variables/Asset.md
+++ b/docs/api-reference/generated/variables/Asset.md
@@ -8,7 +8,7 @@
 
 > `const` **Asset**: `object`
 
-Defined in: [packages/client/src/core/types.ts:92](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L92)
+Defined in: [packages/client/src/core/types.ts:94](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L94)
 
 Canonical asset symbols supported by state-mutating protocol flows.
 

--- a/docs/api-reference/generated/variables/Chain.md
+++ b/docs/api-reference/generated/variables/Chain.md
@@ -8,7 +8,7 @@
 
 > `const` **Chain**: `object`
 
-Defined in: [packages/client/src/core/types.ts:103](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L103)
+Defined in: [packages/client/src/core/types.ts:105](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L105)
 
 Canonical chain identifiers used by wallet and protocol actions.
 

--- a/docs/api-reference/generated/variables/Environment.md
+++ b/docs/api-reference/generated/variables/Environment.md
@@ -8,7 +8,7 @@
 
 > `const` **Environment**: `object`
 
-Defined in: [packages/client/src/core/types.ts:85](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L85)
+Defined in: [packages/client/src/core/types.ts:87](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L87)
 
 Supported deployment environments with bundled canister ids.
 

--- a/docs/api-reference/generated/variables/OutflowType.md
+++ b/docs/api-reference/generated/variables/OutflowType.md
@@ -8,7 +8,7 @@
 
 > `const` **OutflowType**: `object`
 
-Defined in: [packages/client/src/core/types.ts:216](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L216)
+Defined in: [packages/client/src/core/types.ts:218](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L218)
 
 Outflow operation reported by the lending canister.
 

--- a/docs/api-reference/generated/variables/SupplyAction.md
+++ b/docs/api-reference/generated/variables/SupplyAction.md
@@ -8,7 +8,7 @@
 
 > `const` **SupplyAction**: `object`
 
-Defined in: [packages/client/src/core/types.ts:208](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L208)
+Defined in: [packages/client/src/core/types.ts:210](https://github.com/Liquidium-Inc/liquidium-sdk/blob/main/packages/client/src/core/types.ts#L210)
 
 Inflow operation performed by a supply target.
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,12 @@ Released changes for `@liquidium/client`. This page is generated from [`packages
 
 ## @liquidium/client
 
+### 0.8.0
+
+#### Minor Changes
+
+- 3a06781: Allow callers to provide a preconfigured ICP agent through `LiquidiumClientConfig.agent`.
+
 ### 0.7.1
 
 #### Patch Changes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @liquidium/client
 
+## 0.8.0
+
+### Minor Changes
+
+- 3a06781: Allow callers to provide a preconfigured ICP agent through `LiquidiumClientConfig.agent`.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquidium/client",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "The official client for the Liquidium protocol",
   "keywords": [
     "liquidium",


### PR DESCRIPTION
Prepares @liquidium/client 0.8.0 by consuming the custom-agent changeset and updating package and documentation changelogs. Validated with pnpm lint, pnpm build, pnpm typecheck, and pnpm test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the client with a preconfigured ICP agent.

* **Documentation**
  * Documented the new agent configuration option in the changelogs.

* **Release**
  * Released client version 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->