### PR TITLE
chore(client): prepare 0.8.2 release

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -11,6 +11,12 @@ Released changes for `@liquidium/client`. This page is generated from [`packages
 
 ## @liquidium/client
 
+### 0.8.2
+
+#### Patch Changes
+
+- Support the current ICP wallet adoption schema and related canister errors.
+
 ### 0.8.1
 
 #### Patch Changes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @liquidium/client
 
+## 0.8.2
+
+### Patch Changes
+
+- Support the current ICP wallet adoption schema and related canister errors.
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquidium/client",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The official client for the Liquidium protocol",
   "keywords": [
     "liquidium",


### PR DESCRIPTION
Bump @liquidium/client to 0.8.2 and update package and docs changelogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the current ICP wallet adoption schema and related canister errors.

* **Chores**
  * Updated the `@liquidium/client` package to version 0.8.2.
  * Documented the changes in the release changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->